### PR TITLE
Support unquoted attr value recovery for jinja interpolated variables

### DIFF
--- a/markup_fmt/tests/fmt/jinja/attributes/without_quotes_interpolated.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/without_quotes_interpolated.jinja
@@ -1,0 +1,6 @@
+<h4 id={{ id }}>{{ component.id }}</h4>
+<h4 id={{ id }}AA>{{ component.id }}</h4>
+<h4 id=BB{{ id }}AA>{{ component.id }}</h4>
+
+<h4 id=super-{{ id }}-long-{{ id2 }} class="fff">{{ component.id }}</h4>
+<h4 id={{     id  }} class="fff">{{ component.id }}</h4>

--- a/markup_fmt/tests/fmt/jinja/attributes/without_quotes_interpolated.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/without_quotes_interpolated.snap
@@ -1,0 +1,9 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<h4 id="{{ id }}">{{ component.id }}</h4>
+<h4 id="{{ id }}AA">{{ component.id }}</h4>
+<h4 id="BB{{ id }}AA">{{ component.id }}</h4>
+
+<h4 id="super-{{ id }}-long-{{ id2 }}" class="fff">{{ component.id }}</h4>
+<h4 id="{{     id  }}" class="fff">{{ component.id }}</h4>


### PR DESCRIPTION
## Hello ! 

This is an attempt to solve an issue I encountered when using your formatter on **a template with unquoted interpolated attribute value**.
The recovery was slightly wrong, my code was reformated this way resulting in a template rendering issue: 
```diff
-<h4 id={{ component.id }}></h4>
+<h4 id="{{" component.id }}></h4>
```

The whole interpolated value should be quoted because I believe this is what actually happens after a value get's interpolated and finally rendered by a browser.
```html
# `template.jinja`
<h4 id={{ component.id }}></h4>

# `rendered_template.html` with component.id=3
<h4 id=3></h4>

# Resulting html after browser parsing
<h4 id="3"></h4>
```

PS: I'm quite new to rust and your codebase in general so I'll happily update this pr following any suggestion you would make.

PS2: This is part of a bigger effort of making your wonderful formatter compliant with Django template too, If you're open to such improvement, I'll happily open an issue about that. I already started to identify deviations with jinja templates but the syntax is quite similar. 
