### PR TITLE
Add some missing Jinja blocks

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -726,6 +726,9 @@ impl<'s> Parser<'s> {
                 | "autoescape"
                 | "embed"
                 | "with"
+                | "set"
+                | "trans"
+                | "raw"
         ) {
             let mut body = vec![JinjaTagOrChildren::Tag(first_tag)];
 

--- a/markup_fmt/tests/fmt/jinja/control-structure/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/control-structure/fixture.jinja
@@ -50,3 +50,29 @@ Sold-out!
 {%- endmacro %}
 
 <title>{% block title %}{% endblock %}</title>
+
+{% set reply | wordwrap %}
+    You wrote:
+    {{ message }}
+{% endset %}
+
+{% trans %}Hello, {{ user }}!{% endtrans %}
+{% trans user=user.username %}Hello, {{ user }}!{% endtrans %}
+
+{% trans book_title=book.title, author=author.name %}
+This is {{ book_title }} by {{ author }}
+{% endtrans %}
+
+{% trans count=list|length %}
+There is {{ count }} {{ name }} object.
+{% pluralize %}
+There are {{ count }} {{ name }} objects.
+{% endtrans %}
+
+{% raw %}
+<ul>
+{% for item in seq %}
+    <li>{{ item }}</li>
+{% endfor %}
+</ul>
+{% endraw %}

--- a/markup_fmt/tests/fmt/jinja/control-structure/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/control-structure/fixture.snap
@@ -58,3 +58,31 @@ source: markup_fmt/tests/fmt.rs
 {%- endmacro %}
 
 <title>{% block title %}{% endblock %}</title>
+
+{% set reply | wordwrap %}
+  You wrote:
+  {{ message }}
+{% endset %}
+
+{% trans %}Hello, {{ user }}!{% endtrans %}
+{% trans user=user.username %}Hello, {{ user }}!{% endtrans %}
+
+{% trans book_title=book.title, author=author.name %}
+  This is {{ book_title }} by {{ author }}
+{% endtrans %}
+
+{% trans count=list|length %}
+  There is {{ count }}
+  {{ name }} object.
+  {% pluralize %}
+  There are {{ count }}
+  {{ name }} objects.
+{% endtrans %}
+
+{% raw %}
+  <ul>
+    {% for item in seq %}
+      <li>{{ item }}</li>
+    {% endfor %}
+  </ul>
+{% endraw %}


### PR DESCRIPTION
Add support for the following jinja blocks `set` / `trans` / `raw`.

I added tests cases using code samples from the [jinja documentation](https://jinja.palletsprojects.com/en/3.1.x/templates/) about these tags.

I would also like to add support for custom blocks such as `{% markdown %}...{% endmarkdown %}` (https://github.com/jpsca/jinja-markdown).

Would it be okay to add a `custom_blocks` configuration allowing people to list custom block they use ?
I'm not sure how often this is used in jinja but it's quite common in django (See django documentation on [how to implement custom blocks](https://docs.djangoproject.com/en/5.0/howto/custom-template-tags/#parsing-until-another-block-tag-and-saving-contents))