### PR TITLE
Avoid wrapping for multiple text-like nodes

### DIFF
--- a/dprint_plugin/tests/integration/biome/nested-template.astro.snap
+++ b/dprint_plugin/tests/integration/biome/nested-template.astro.snap
@@ -26,8 +26,7 @@ source: dprint_plugin/tests/integration.rs
     {
       fields.map((field) => (
         <p class="instructions">
-          {"To get started, o"}{"pen the directory"}
-          {"in your project."}
+          {"To get started, o"}{"pen the directory"} {"in your project."}
         </p>
       ))
     }

--- a/dprint_plugin/tests/integration/dprint_ts/nested-template.astro.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/nested-template.astro.snap
@@ -26,8 +26,7 @@ source: dprint_plugin/tests/integration.rs
     {
       fields.map((field) => (
         <p class="instructions">
-          {"To get started, o"}{"pen the directory"}
-          {"in your project."}
+          {"To get started, o"}{"pen the directory"} {"in your project."}
         </p>
       ))
     }

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -360,37 +360,20 @@ impl<'s> DocGen<'s> for Element<'s> {
             Doc::nil()
         } else if is_whitespace_sensitive {
             format_ws_sensitive_leading_ws(&self.children)
-        } else if has_two_more_non_text_children
-            || self
-                .children
-                .first()
-                .map(|child| match child {
-                    Node::Text(text_node) => text_node.line_breaks > 0,
-                    _ => false,
-                })
-                .unwrap_or_default()
-        {
+        } else if has_two_more_non_text_children {
             Doc::hard_line()
         } else {
-            Doc::line_or_nil()
+            format_ws_insensitive_leading_ws(&self.children)
         };
+
         let trailing_ws = if is_empty {
             Doc::nil()
         } else if is_whitespace_sensitive {
             format_ws_sensitive_trailing_ws(&self.children)
-        } else if has_two_more_non_text_children
-            || self
-                .children
-                .last()
-                .map(|child| match child {
-                    Node::Text(text_node) => text_node.line_breaks > 0,
-                    _ => false,
-                })
-                .unwrap_or_default()
-        {
+        } else if has_two_more_non_text_children {
             Doc::hard_line()
         } else {
-            Doc::line_or_nil()
+            format_ws_insensitive_trailing_ws(&self.children)
         };
         if tag_name.eq_ignore_ascii_case("script") {
             if let [Node::Text(text_node)] = &self.children[..] {
@@ -1746,7 +1729,18 @@ fn format_ws_sensitive_trailing_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
         Doc::nil()
     }
 }
-
+fn format_ws_insensitive_leading_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
+    match children.first() {
+        Some(Node::Text(text_node)) if text_node.line_breaks > 0 => Doc::hard_line(),
+        _ => Doc::line_or_nil(),
+    }
+}
+fn format_ws_insensitive_trailing_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
+    match children.last() {
+        Some(Node::Text(text_node)) if text_node.line_breaks > 0 => Doc::hard_line(),
+        _ => Doc::line_or_nil(),
+    }
+}
 fn format_v_for<'s, E, F>(
     left: &str,
     delimiter: &'static str,

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -356,7 +356,9 @@ impl<'s> DocGen<'s> for Element<'s> {
         };
         let has_two_more_non_text_children = has_two_more_non_text_children(&self.children);
 
-        let leading_ws = if is_whitespace_sensitive {
+        let leading_ws = if is_empty {
+            Doc::nil()
+        } else if is_whitespace_sensitive {
             format_ws_sensitive_leading_ws(&self.children)
         } else if has_two_more_non_text_children
             || self
@@ -369,12 +371,12 @@ impl<'s> DocGen<'s> for Element<'s> {
                 .unwrap_or_default()
         {
             Doc::hard_line()
-        } else if is_empty {
-            Doc::nil()
         } else {
             Doc::line_or_nil()
         };
-        let trailing_ws = if is_whitespace_sensitive {
+        let trailing_ws = if is_empty {
+            Doc::nil()
+        } else if is_whitespace_sensitive {
             format_ws_sensitive_trailing_ws(&self.children)
         } else if has_two_more_non_text_children
             || self
@@ -387,12 +389,9 @@ impl<'s> DocGen<'s> for Element<'s> {
                 .unwrap_or_default()
         {
             Doc::hard_line()
-        } else if is_empty {
-            Doc::nil()
         } else {
             Doc::line_or_nil()
         };
-
         if tag_name.eq_ignore_ascii_case("script") {
             if let [Node::Text(text_node)] = &self.children[..] {
                 if text_node.raw.chars().all(|c| c.is_ascii_whitespace()) {

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1556,16 +1556,7 @@ where
             .fold(
                 (Vec::with_capacity(children.len() * 2), true),
                 |(mut docs, is_prev_text_like), (i, child)| {
-                    let is_current_text_like = match child {
-                        Node::Text(..)
-                        | Node::VueInterpolation(..)
-                        | Node::SvelteInterpolation(..)
-                        | Node::AstroExpr(..)
-                        | Node::JinjaInterpolation(..)
-                        | Node::VentoInterpolation(..) => true,
-                        Node::Element(element) => element.tag_name.eq_ignore_ascii_case("label"),
-                        _ => false,
-                    };
+                    let is_current_text_like = is_text_like(child);
                     let maybe_hard_line = if is_prev_text_like || is_current_text_like {
                         None
                     } else {
@@ -1611,6 +1602,21 @@ where
             .0,
     )
     .group()
+}
+
+/// Determines if a given node is "text-like".
+/// Text-like nodes should remain on the same line whenever possible.
+fn is_text_like(node: &Node) -> bool {
+    match node {
+        Node::Text(..)
+        | Node::VueInterpolation(..)
+        | Node::SvelteInterpolation(..)
+        | Node::AstroExpr(..)
+        | Node::JinjaInterpolation(..)
+        | Node::VentoInterpolation(..) => true,
+        Node::Element(element) => element.tag_name.eq_ignore_ascii_case("label"),
+        _ => false,
+    }
 }
 
 fn format_children_without_inserting_linebreak<'s, E, F>(

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1501,11 +1501,7 @@ fn should_add_whitespace_after_text_node<'s>(
 }
 
 fn has_two_more_non_text_children(children: &[Node]) -> bool {
-    children
-        .iter()
-        .filter(|child| !matches!(child, Node::Text(_)))
-        .count()
-        > 1
+    children.iter().filter(|child| !is_text_like(child)).count() > 1
 }
 
 fn format_attr_value<'a>(

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -356,25 +356,22 @@ impl<'s> DocGen<'s> for Element<'s> {
         };
         let has_two_more_non_text_children = has_two_more_non_text_children(&self.children);
 
-        let leading_ws = if is_empty {
-            Doc::nil()
+        let (leading_ws, trailing_ws) = if is_empty {
+            (Doc::nil(), Doc::nil())
         } else if is_whitespace_sensitive {
-            format_ws_sensitive_leading_ws(&self.children)
+            (
+                format_ws_sensitive_leading_ws(&self.children),
+                format_ws_sensitive_trailing_ws(&self.children),
+            )
         } else if has_two_more_non_text_children {
-            Doc::hard_line()
+            (Doc::hard_line(), Doc::hard_line())
         } else {
-            format_ws_insensitive_leading_ws(&self.children)
+            (
+                format_ws_insensitive_leading_ws(&self.children),
+                format_ws_insensitive_trailing_ws(&self.children),
+            )
         };
 
-        let trailing_ws = if is_empty {
-            Doc::nil()
-        } else if is_whitespace_sensitive {
-            format_ws_sensitive_trailing_ws(&self.children)
-        } else if has_two_more_non_text_children {
-            Doc::hard_line()
-        } else {
-            format_ws_insensitive_trailing_ws(&self.children)
-        };
         if tag_name.eq_ignore_ascii_case("script") {
             if let [Node::Text(text_node)] = &self.children[..] {
                 if text_node.raw.chars().all(|c| c.is_ascii_whitespace()) {

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.jinja
@@ -7,3 +7,20 @@
 <span>{{ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx }}</span>
 
 <div>{{ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx }}</div>
+
+<div>Hello {{ user.first_name }} {{ user.last_name }}!</div>
+
+<span>Hello {{ user.first_name }} {{ user.last_name }}!</span>
+
+<div>Flat rate for {{ nb_months }} month{{ nb_months|pluralize }}</div>
+
+<div>{{ first_idx }}-{{ last_idx }} of {{ total_count }} lines</div>
+
+<div>
+  Hello {{ user.first_name }} {{ user.last_name }}!
+</div>
+<span>
+  Hello
+  {{ user.first_name }}
+  {{ user.last_name }}!
+</span>

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
@@ -14,3 +14,29 @@ source: markup_fmt/tests/fmt.rs
 <div>
   {{ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx }}
 </div>
+
+<div>
+  Hello {{ user.first_name }}
+  {{ user.last_name }}!
+</div>
+
+<span>Hello {{ user.first_name }}
+  {{ user.last_name }}!</span>
+
+<div>
+  Flat rate for {{ nb_months }} month{{ nb_months|pluralize }}
+</div>
+
+<div>
+  {{ first_idx }}-{{ last_idx }} of {{ total_count }} lines
+</div>
+
+<div>
+  Hello {{ user.first_name }}
+  {{ user.last_name }}!
+</div>
+<span>
+  Hello
+  {{ user.first_name }}
+  {{ user.last_name }}!
+</span>

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
@@ -2,9 +2,7 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <div>
-  {{ x }}
-  {{ x }}
-  {{ x }}
+  {{ x }} {{ x }} {{ x }}
 </div>
 
 <span>{{
@@ -15,25 +13,16 @@ source: markup_fmt/tests/fmt.rs
   {{ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx }}
 </div>
 
-<div>
-  Hello {{ user.first_name }}
-  {{ user.last_name }}!
-</div>
+<div>Hello {{ user.first_name }} {{ user.last_name }}!</div>
 
-<span>Hello {{ user.first_name }}
-  {{ user.last_name }}!</span>
+<span>Hello {{ user.first_name }} {{ user.last_name }}!</span>
 
-<div>
-  Flat rate for {{ nb_months }} month{{ nb_months|pluralize }}
-</div>
+<div>Flat rate for {{ nb_months }} month{{ nb_months|pluralize }}</div>
+
+<div>{{ first_idx }}-{{ last_idx }} of {{ total_count }} lines</div>
 
 <div>
-  {{ first_idx }}-{{ last_idx }} of {{ total_count }} lines
-</div>
-
-<div>
-  Hello {{ user.first_name }}
-  {{ user.last_name }}!
+  Hello {{ user.first_name }} {{ user.last_name }}!
 </div>
 <span>
   Hello

--- a/markup_fmt/tests/fmt/svelte/at-tags/at-tags.snap
+++ b/markup_fmt/tests/fmt/svelte/at-tags/at-tags.snap
@@ -3,8 +3,7 @@ source: markup_fmt/tests/fmt.rs
 ---
 {#each [1, 2] as foo}
   {@const bar =
-        foo}
-  {foo}{bar}
+        foo} {foo}{bar}
 {/each}
 
 {#await aPromise then result}

--- a/markup_fmt/tests/fmt/svelte/await-block/destructuring.snap
+++ b/markup_fmt/tests/fmt/svelte/await-block/destructuring.snap
@@ -2,49 +2,41 @@
 source: markup_fmt/tests/fmt.rs
 ---
 {#await promise then {  a,b =''}}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise}
   Loading
 {:then {  a,b =''}}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise then [  a,b ='']}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise}
   Loading
 {:then [  a,b ='']}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise catch {  a,b =''}}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise}
   Loading
 {:catch {  a,b =''}}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise catch [  a,b ='']}
-  {a}
-  {b}
+  {a} {b}
 {/await}
 
 {#await promise}
   Loading
 {:catch [  a,b ='']}
-  {a}
-  {b}
+  {a} {b}
 {/await}

--- a/markup_fmt/tests/fmt/svelte/each-block/destructuring.snap
+++ b/markup_fmt/tests/fmt/svelte/each-block/destructuring.snap
@@ -2,11 +2,9 @@
 source: markup_fmt/tests/fmt.rs
 ---
 {#each arr as {  a,b =''}}
-  {a}
-  {b}
+  {a} {b}
 {/each}
 
 {#each arr as [  a,b ='']}
-  {a}
-  {b}
+  {a} {b}
 {/each}

--- a/markup_fmt/tests/fmt/svelte/each-block/key.snap
+++ b/markup_fmt/tests/fmt/svelte/each-block/key.snap
@@ -2,14 +2,10 @@
 source: markup_fmt/tests/fmt.rs
 ---
 {#each items as item (item.id)}
-  <li>
-    {item.name} x {item.qty}
-  </li>
+  <li>{item.name} x {item.qty}</li>
 {/each}
 
 <!-- or with additional index value -->
 {#each items as item, i (item.id)}
-  <li>
-    {i + 1}: {item.name} x {item.qty}
-  </li>
+  <li>{i + 1}: {item.name} x {item.qty}</li>
 {/each}

--- a/markup_fmt/tests/fmt/svelte/each-block/loop-index.snap
+++ b/markup_fmt/tests/fmt/svelte/each-block/loop-index.snap
@@ -2,7 +2,5 @@
 source: markup_fmt/tests/fmt.rs
 ---
 {#each items as item, i}
-  <li>
-    {i + 1}: {item.name} x {item.qty}
-  </li>
+  <li>{i + 1}: {item.name} x {item.qty}</li>
 {/each}

--- a/markup_fmt/tests/fmt/vue/interpolation/parenthesized.snap
+++ b/markup_fmt/tests/fmt/vue/interpolation/parenthesized.snap
@@ -2,6 +2,5 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <template>
-  <span>{{ (a||          b) }}
-    {{ z&&(a&&b) }}</span>
+  <span>{{ (a||          b) }} {{ z&&(a&&b) }}</span>
 </template>


### PR DESCRIPTION
Hi! 

`markup_fmt` seems to force wrapping when there are more than 2 non-text element in an html element. 
This introduces some unusual wrapping when there are **2+ jinja interpolation inside an element** (which is actually quite common).

```diff
-<div>Hello {{ user.first_name }} {{ user.last_name }}!</div>
+<div>
+  Hello {{ user.first_name }}
+  {{ user.last_name }}!
+</div>
```

This MR changes the behavior slightly to check for text-like nodes (reusing existing logic to identify them). 

**You should probably review this commit per commit** because I also did some small refactoring along the way when I was trying to figure out the leading/trailing ws handling. I made sure every commit was always passing the test suite. Only the last commit introduces the behavior change described above.

I'll be happy to make any changes if my implementation doesn't satisfy you needs.
Cheers 
