### PR TITLE
Fix panic for empty line in script tag containing only a tab (or few spaces)

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1434,7 +1434,7 @@ fn reflow_with_indent<'i, 'o: 'i>(s: &'i str) -> impl Iterator<Item = Doc<'o>> +
         .unwrap_or_default();
     s.split('\n').enumerate().flat_map(move |(i, s)| {
         let s = s.strip_suffix('\r').unwrap_or(s);
-        let s = if s.starts_with([' ', '\t']) {
+        let s = if s.starts_with([' ', '\t']) && s.len() >= indent {
             &s[indent..]
         } else {
             s

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1434,8 +1434,8 @@ fn reflow_with_indent<'i, 'o: 'i>(s: &'i str) -> impl Iterator<Item = Doc<'o>> +
         .unwrap_or_default();
     s.split('\n').enumerate().flat_map(move |(i, s)| {
         let s = s.strip_suffix('\r').unwrap_or(s);
-        let s = if s.starts_with([' ', '\t']) && s.len() >= indent {
-            &s[indent..]
+        let s = if s.starts_with([' ', '\t']) {
+            &s.get(indent..).unwrap_or(s)
         } else {
             s
         };

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.both.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.both.snap
@@ -12,7 +12,7 @@ source: markup_fmt/tests/fmt.rs
         text-decoration: none;
       }
       /* Next line is just 2 spaces */
- 
+  
       /* --- */
     </style>
     <script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.both.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.both.snap
@@ -7,6 +7,14 @@ source: markup_fmt/tests/fmt.rs
     <style>
       a { text-decoration: none; }
     </style>
+    <style>
+      a {
+        text-decoration: none;
+      }
+      /* Next line is just 2 spaces */
+ 
+      /* --- */
+    </style>
     <script>
       window.addEventListener('load', () => {})
     </script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.html
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.html
@@ -2,6 +2,14 @@
 <html lang="en">
   <body>
     <style>a { text-decoration: none; }</style>
+    <style>
+      a {
+        text-decoration: none;
+      }
+      /* Next line is just 2 spaces */
+ 
+      /* --- */
+    </style>
     <script>window.addEventListener('load', () => {})</script>
   </body>
 </html>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.html
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.html
@@ -7,7 +7,7 @@
         text-decoration: none;
       }
       /* Next line is just 2 spaces */
- 
+  
       /* --- */
     </style>
     <script>window.addEventListener('load', () => {})</script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.override-script.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.override-script.snap
@@ -12,7 +12,7 @@ source: markup_fmt/tests/fmt.rs
       text-decoration: none;
     }
     /* Next line is just 2 spaces */
- 
+  
     /* --- */
     </style>
     <script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.override-script.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.override-script.snap
@@ -7,6 +7,14 @@ source: markup_fmt/tests/fmt.rs
     <style>
     a { text-decoration: none; }
     </style>
+    <style>
+    a {
+      text-decoration: none;
+    }
+    /* Next line is just 2 spaces */
+ 
+    /* --- */
+    </style>
     <script>
       window.addEventListener('load', () => {})
     </script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.override-style.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.override-style.snap
@@ -12,7 +12,7 @@ source: markup_fmt/tests/fmt.rs
         text-decoration: none;
       }
       /* Next line is just 2 spaces */
- 
+  
       /* --- */
     </style>
     <script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.override-style.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.override-style.snap
@@ -7,6 +7,14 @@ source: markup_fmt/tests/fmt.rs
     <style>
       a { text-decoration: none; }
     </style>
+    <style>
+      a {
+        text-decoration: none;
+      }
+      /* Next line is just 2 spaces */
+ 
+      /* --- */
+    </style>
     <script>
     window.addEventListener('load', () => {})
     </script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.script.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.script.snap
@@ -12,7 +12,7 @@ source: markup_fmt/tests/fmt.rs
       text-decoration: none;
     }
     /* Next line is just 2 spaces */
- 
+  
     /* --- */
     </style>
     <script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.script.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.script.snap
@@ -7,6 +7,14 @@ source: markup_fmt/tests/fmt.rs
     <style>
     a { text-decoration: none; }
     </style>
+    <style>
+    a {
+      text-decoration: none;
+    }
+    /* Next line is just 2 spaces */
+ 
+    /* --- */
+    </style>
     <script>
       window.addEventListener('load', () => {})
     </script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.style.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.style.snap
@@ -12,7 +12,7 @@ source: markup_fmt/tests/fmt.rs
         text-decoration: none;
       }
       /* Next line is just 2 spaces */
- 
+  
       /* --- */
     </style>
     <script>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.style.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.style.snap
@@ -7,6 +7,14 @@ source: markup_fmt/tests/fmt.rs
     <style>
       a { text-decoration: none; }
     </style>
+    <style>
+      a {
+        text-decoration: none;
+      }
+      /* Next line is just 2 spaces */
+ 
+      /* --- */
+    </style>
     <script>
     window.addEventListener('load', () => {})
     </script>


### PR DESCRIPTION
This fixes an error I discovered by formatting this snippet containing a mix of 2 and 4 spaces indents with `markup_fmt`.

```diff
<head>
    <style>
      .foo .icon {
        height: 32px;
        width: 32px;
      }
      
      .foo {
        margin: 0;
      }
    </style>
</head>
```
The first pass lead to this:
```diff
<head>
    <style>
    .foo .icon {
      height: 32px;
      width: 32px;
    }
-    
+  
    .foo {
      margin: 0;
    }
    </style>
</head>
```
And the second one panicked because of the 2-space indent between the css classes