### PR TITLE
Format Jinja/block tag in html tag opening

### DIFF
--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -60,6 +60,7 @@ pub enum Attribute<'s> {
     Native(NativeAttribute<'s>),
     Svelte(SvelteAttribute<'s>),
     VueDirective(VueDirective<'s>),
+    JinjaTagOrBlock(Node<'s>),
 }
 
 pub struct Comment<'s> {

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -602,7 +602,7 @@ impl<'s> Parser<'s> {
 
     fn parse_attr(&mut self) -> PResult<Attribute<'s>> {
         match self.language {
-            Language::Html | Language::Jinja | Language::Vento | Language::Angular => {
+            Language::Html | Language::Vento | Language::Angular => {
                 self.parse_native_attr().map(Attribute::Native)
             }
             Language::Vue => self
@@ -616,6 +616,10 @@ impl<'s> Parser<'s> {
             Language::Astro => self
                 .try_parse(Parser::parse_astro_attr)
                 .map(Attribute::Astro)
+                .or_else(|_| self.parse_native_attr().map(Attribute::Native)),
+            Language::Jinja => self
+                .try_parse(|parser| parser.parse_jinja_tag_or_block(None))
+                .map(Attribute::JinjaTagOrBlock)
                 .or_else(|_| self.parse_native_attr().map(Attribute::Native)),
         }
     }

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -294,6 +294,7 @@ impl<'s> DocGen<'s> for Attribute<'s> {
             Attribute::Svelte(svelte_attribute) => svelte_attribute.doc(ctx, state),
             Attribute::VueDirective(vue_directive) => vue_directive.doc(ctx, state),
             Attribute::Astro(astro_attribute) => astro_attribute.doc(ctx, state),
+            Attribute::JinjaTagOrBlock(jinja_tag_or_block) => jinja_tag_or_block.doc(ctx, state),
         }
     }
 }

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
@@ -1,3 +1,9 @@
+<div {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %} {% if colored_with_days %}colored-with-days{% endif %}>
+</div>
+
+<div class="flex" {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %} id="3">
+</div>
+
 <div{% if id %} id="{{ id }}" {% endif %}class="flex gap-10"></div>
 
 <div {% if id != 1 %}class="active"{% endif %}></div>
@@ -42,3 +48,38 @@
 <details {% if category == "active" %}open{% endif %} ></details>
 
 <input type="radio" name="{{ field.name }}" id="id_{{ field.name }}{{ forloop.count }}" value="{{ choice.0 }}" {% if choice.0 == field.value %}checked="checked"{% endif %} />
+
+<input
+    id="id_callback"
+    type="radio"
+    name="callback_method"
+    value="callback"
+    {% if not office_open %} disabled class="hidden" {% endif %}
+>
+
+<div class="flex foo"
+    id="index_id"
+    {% if index_type == "foo" %}style="display: none"{% endif %}>
+    My text that should sometimes be hidden
+</div>
+
+<div data-toggle-mobile="true"
+    {% if "adsl" not in connectivity_technology %}data-filter="fiber"{% endif %}
+    class="foo bar baz yayayayayayaya">
+    Data attributes
+</div>
+
+{% for subentry in entry.subentries %}
+    {% if subentry.url %}
+        <li>
+            <a
+                href="{{ subentry.url }}"
+                {% if subentry.active %}
+                  class="dropdown-menu-selected"
+                {% endif %}
+            >{{ subentry.name }}</a>
+        </li>
+    {% else %}
+        <li class="nav-internal-link--dropdown--separator">{{ subentry.name }}</li>
+    {% endif %}
+{% endfor %}

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
@@ -1,0 +1,41 @@
+{# Jinja tags/block inside html element opening tag #}
+
+<div{% if id %} id="{{ id }}" {% endif %}class="flex gap-10"></div>
+
+<input type='text' hidden {% if widget.required is not False %}required{% endif %}/>
+
+<details {% if category %}open{% endif %} >
+  <summary>Details</summary>
+  Something small enough to escape casual notice.
+</details>
+
+<details {% if category %}open{% endif %}
+         class="group"></details>
+
+<form class="fff" {% if reload %} action="{{ request.get_full_path }}" {% else %}  data-url="{{ request.get_full_path }}" {% endif %}></form>
+
+<div class="input">
+    {% if unit and unit_side == "left" %} <span class="{% if not unit_bg %}input__unit{% endif %}{% if unit_bg %} input__bg-unit{% endif %}">{{ unit }}</span> {% endif %}
+    {% include "django/forms/widgets/input.html" %}
+    {% if unit and unit_side == "right" %} <span class="{% if not unit_bg %}input__unit{% endif %}{% if unit_bg %} input__bg-unit{% endif %}">{{ unit }}</span> {% endif %}
+</div>
+
+<div class="calendar__data hidden"
+     {% if widget_datepicker %}
+        {% for key, value in widget_datepicker.working_hours.items %}
+            data-{{key}}="{{value}}"
+        {% endfor %}
+    {% elif datepicker %}
+        {% if datepicker.should_delay %}
+            data-should_delay
+        {% endif %}
+    {% else %}
+        data-start='08:30:00'
+        data-end='20:30:00'
+        data-start_day='{% now "Y-m-d" %}'
+        data-saturday_start='08:30:00'
+        data-saturday_end='20:30:00'
+    {% endif %}
+>
+</div>
+

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
@@ -2,6 +2,8 @@
 
 <div{% if id %} id="{{ id }}" {% endif %}class="flex gap-10"></div>
 
+<div {% if id != 1 %}class="active"{% endif %}></div>
+
 <input type='text' hidden {% if widget.required is not False %}required{% endif %}/>
 
 <details {% if category %}open{% endif %} >
@@ -39,3 +41,6 @@
 >
 </div>
 
+<details {% if category == "active" %}open{% endif %} ></details>
+
+<input type="radio" name="{{ field.name }}" id="id_{{ field.name }}{{ forloop.count }}" value="{{ choice.0 }}" {% if choice.0 == field.value %}checked="checked"{% endif %} />

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.jinja
@@ -1,5 +1,3 @@
-{# Jinja tags/block inside html element opening tag #}
-
 <div{% if id %} id="{{ id }}" {% endif %}class="flex gap-10"></div>
 
 <div {% if id != 1 %}class="active"{% endif %}></div>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
@@ -1,0 +1,101 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+{# Jinja tags/block inside html element opening tag #}
+
+<div {% if id %} id="{{ id }}" {% endif %} class="flex gap-10"></div>
+
+<input
+  type="text"
+  hidden
+  {%
+  if
+  widget.required
+  is
+  not
+  False
+  %}required{%
+  endif
+  %}
+/>
+
+<details {% if category %}open{% endif %}>
+  <summary>Details</summary>
+  Something small enough to escape casual notice.
+</details>
+
+<details {% if category %}open{% endif %} class="group"></details>
+
+<form
+  class="fff"
+  {%
+  if
+  reload
+  %}
+  action="{{ request.get_full_path }}"
+  {%
+  else
+  %}
+  data-url="{{ request.get_full_path }}"
+  {%
+  endif
+  %}
+>
+</form>
+
+<div class="input">
+  {% if unit and unit_side == "left" %}
+    <span
+      class="{% if not unit_bg %}input__unit{% endif %}{% if unit_bg %} input__bg-unit{% endif %}"
+    >{{ unit }}</span>
+  {% endif %}
+  {% include "django/forms/widgets/input.html" %}
+  {% if unit and unit_side == "right" %}
+    <span
+      class="{% if not unit_bg %}input__unit{% endif %}{% if unit_bg %} input__bg-unit{% endif %}"
+    >{{ unit }}</span>
+  {% endif %}
+</div>
+
+<div
+  class="calendar__data hidden"
+  {%
+  if
+  widget_datepicker
+  %}
+  {%
+  for
+  key,
+  value
+  in
+  widget_datepicker.working_hours.items
+  %}
+  data-{{key}}="{{value}}"
+  {%
+  endfor
+  %}
+  {%
+  elif
+  datepicker
+  %}
+  {%
+  if
+  datepicker.should_delay
+  %}
+  data-should_delay
+  {%
+  endif
+  %}
+  {%
+  else
+  %}
+  data-start="08:30:00"
+  data-end="20:30:00"
+  data-start_day='{% now "Y-m-d" %}'
+  data-saturday_start="08:30:00"
+  data-saturday_end="20:30:00"
+  {%
+  endif
+  %}
+>
+</div>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
@@ -1,24 +1,14 @@
 ---
 source: markup_fmt/tests/fmt.rs
 ---
-{# Jinja tags/block inside html element opening tag #}
+<div {% if id %} id="{{ id }}" {% endif %} class="flex gap-10"></div>
 
-<div {% if id %} id="{{ id }}" {% endif %}class="flex gap-10"></div>
-
-<div {% if id !="1" %}class="active" {% endif %}></div>
+<div {% if id != 1 %}class="active"{% endif %}></div>
 
 <input
   type="text"
   hidden
-  {%
-  if
-  widget.required
-  is
-  not
-  False
-  %}required{%
-  endif
-  %}
+  {% if widget.required is not False %}required{% endif %}
 />
 
 <details {% if category %}open{% endif %}>
@@ -30,18 +20,11 @@ source: markup_fmt/tests/fmt.rs
 
 <form
   class="fff"
-  {%
-  if
-  reload
-  %}
-  action="{{ request.get_full_path }}"
-  {%
-  else
-  %}
-  data-url="{{ request.get_full_path }}"
-  {%
-  endif
-  %}
+  {% if reload %}
+    action="{{ request.get_full_path }}"
+  {% else %}
+    data-url="{{ request.get_full_path }}"
+  {% endif %}
 >
 </form>
 
@@ -61,43 +44,27 @@ source: markup_fmt/tests/fmt.rs
 
 <div
   class="calendar__data hidden"
-  {%
-  if
-  widget_datepicker
-  %}
-  {%
-  for
-  key,
-  value
-  in
-  widget_datepicker.working_hours.items
-  %}
-  data-{{key}}="{{value}}"
-  {%
-  endfor
-  %}
-  {%
-  elif
-  datepicker
-  %}
-  {%
-  if
-  datepicker.should_delay
-  %}
-  data-should_delay
-  {%
-  endif
-  %}
-  {%
-  else
-  %}
-  data-start="08:30:00"
-  data-end="20:30:00"
-  data-start_day='{% now "Y-m-d" %}'
-  data-saturday_start="08:30:00"
-  data-saturday_end="20:30:00"
-  {%
-  endif
-  %}
+  {% if widget_datepicker %}
+    {% for key, value in widget_datepicker.working_hours.items %}
+      data-{{ key }}="{{ value }}"
+    {% endfor %}
+  {% elif datepicker %}
+    {% if datepicker.should_delay %}
+      data-should_delay
+    {% endif %}
+  {% else %}
+    data-start='08:30:00' data-end='20:30:00' data-start_day='{% now "Y-m-d" %}'
+    data-saturday_start='08:30:00' data-saturday_end='20:30:00'
+  {% endif %}
 >
 </div>
+
+<details {% if category == "active" %}open{% endif %}></details>
+
+<input
+  type="radio"
+  name="{{ field.name }}"
+  id="id_{{ field.name }}{{ forloop.count }}"
+  value="{{ choice.0 }}"
+  {% if choice.0 == field.value %}checked="checked"{% endif %}
+/>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
@@ -1,6 +1,19 @@
 ---
 source: markup_fmt/tests/fmt.rs
 ---
+<div
+  {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %}
+  {% if colored_with_days %}colored-with-days{% endif %}
+>
+</div>
+
+<div
+  class="flex"
+  {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %}
+  id="3"
+>
+</div>
+
 <div {% if id %} id="{{ id }}" {% endif %} class="flex gap-10"></div>
 
 <div {% if id != 1 %}class="active"{% endif %}></div>
@@ -68,3 +81,44 @@ source: markup_fmt/tests/fmt.rs
   value="{{ choice.0 }}"
   {% if choice.0 == field.value %}checked="checked"{% endif %}
 />
+
+<input
+  id="id_callback"
+  type="radio"
+  name="callback_method"
+  value="callback"
+  {% if not office_open %}
+    disabled class="hidden"
+  {% endif %}
+>
+
+<div
+  class="flex foo"
+  id="index_id"
+  {% if index_type == "foo" %}style="display: none"{% endif %}
+>
+  My text that should sometimes be hidden
+</div>
+
+<div
+  data-toggle-mobile="true"
+  {% if "adsl" not in connectivity_technology %}data-filter="fiber"{% endif %}
+  class="foo bar baz yayayayayayaya"
+>
+  Data attributes
+</div>
+
+{% for subentry in entry.subentries %}
+  {% if subentry.url %}
+    <li>
+      <a
+        href="{{ subentry.url }}"
+        {% if subentry.active %}
+          class="dropdown-menu-selected"
+        {% endif %}
+      >{{ subentry.name }}</a>
+    </li>
+  {% else %}
+    <li class="nav-internal-link--dropdown--separator">{{ subentry.name }}</li>
+  {% endif %}
+{% endfor %}

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
@@ -3,7 +3,9 @@ source: markup_fmt/tests/fmt.rs
 ---
 {# Jinja tags/block inside html element opening tag #}
 
-<div {% if id %} id="{{ id }}" {% endif %} class="flex gap-10"></div>
+<div {% if id %} id="{{ id }}" {% endif %}class="flex gap-10"></div>
+
+<div {% if id !="1" %}class="active" {% endif %}></div>
 
 <input
   type="text"

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.jinja
@@ -5,7 +5,7 @@
     href='https://{{ request.get_host }}{% url "newsletter_verify" uuid=subscription.verification_token %}'
 >Subscribe to the newsletter!</a>
 <div
-  class="first-class {% block extra_classes %}{% endblock %} modal fade">
+  class="first-class {% block extra_classes %}{% endblock %} modal fade"
   aria-hidden="true"
 ></div>
 <div id="cookie-modal__form" class="modal cookie-modal {% if should_hide %}initial-hidden{% endif %}"></div>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.jinja
@@ -1,5 +1,3 @@
-{# Jinja tags/block inside attribute values #}
-
 <form class="form-control" action='{% url "my_app:subscribe" %}' method="post">
   {{ whatever }}
 </form>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.jinja
@@ -1,0 +1,13 @@
+{# Jinja tags/block inside attribute values #}
+
+<form class="form-control" action='{% url "my_app:subscribe" %}' method="post">
+  {{ whatever }}
+</form>
+<a
+    href='https://{{ request.get_host }}{% url "newsletter_verify" uuid=subscription.verification_token %}'
+>Subscribe to the newsletter!</a>
+<div
+  class="first-class {% block extra_classes %}{% endblock %} modal fade">
+  aria-hidden="true"
+></div>
+<div id="cookie-modal__form" class="modal cookie-modal {% if should_hide %}initial-hidden{% endif %}"></div>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
@@ -1,8 +1,6 @@
 ---
 source: markup_fmt/tests/fmt.rs
 ---
-{# Jinja tags/block inside attribute values #}
-
 <form class="form-control" action='{% url "my_app:subscribe" %}' method="post">
   {{ whatever }}
 </form>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
@@ -1,0 +1,19 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+{# Jinja tags/block inside attribute values #}
+
+<form class="form-control" action='{% url "my_app:subscribe" %}' method="post">
+  {{ whatever }}
+</form>
+<a
+  href='https://{{ request.get_host }}{% url "newsletter_verify" uuid=subscription.verification_token %}'
+>Subscribe to the newsletter!</a>
+<div class="first-class {% block extra_classes %}{% endblock %} modal fade">
+  aria-hidden="true" >
+</div>
+<div
+  id="cookie-modal__form"
+  class="modal cookie-modal {% if should_hide %}initial-hidden{% endif %}"
+>
+</div>

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
@@ -7,8 +7,10 @@ source: markup_fmt/tests/fmt.rs
 <a
   href='https://{{ request.get_host }}{% url "newsletter_verify" uuid=subscription.verification_token %}'
 >Subscribe to the newsletter!</a>
-<div class="first-class {% block extra_classes %}{% endblock %} modal fade">
-  aria-hidden="true" >
+<div
+  class="first-class {% block extra_classes %}{% endblock %} modal fade"
+  aria-hidden="true"
+>
 </div>
 <div
   id="cookie-modal__form"


### PR DESCRIPTION
Hello !

This patch tries to parse more precisely Jinja Tag & Block used inside html opening tags. I've tried to match the existing approach for Vue/svelte/astro.
This is probably easier to review commit per commit to see the changes on the test snapshots.

Test cases are mostly real life anonymised snippets from my codebase at work.

---
For context, Prior to this change, jinja block / tags where formatted weirdly inside html tag opening because they where just split on spaces and considered a bunch of attributes. This resulted in this kind of formatting:
```diff
-<div {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %} {% if colored_with_days %}colored-with-days{% endif %}>
-</div>
+<div
+    {%
+    if
+    colored_with_absolute_dates
+    %}colored-with-absolute-dates{%
+    endif
+    %}
+    {%
+    if
+    colored_with_days
+    %}colored-with-days{%
+    endif
+    %}
+>
+</div>
```

It was also failing to parse sometimes, for example if there is a `==` inside the tag because the parser was expecting a normal `attr=value` html attribute. 
For exemple, `<details {% if category == "active" %}open{% endif %} ></details>` could not be parsed.
