### PR TITLE
Invalid offset when formatting multiline attr value

### DIFF
--- a/markup_fmt/tests/fmt/html/attributes/style.html
+++ b/markup_fmt/tests/fmt/html/attributes/style.html
@@ -52,3 +52,84 @@ style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-pro
 
 <div style="color: red; {{ otherStyles }}"
 ></div>
+
+<!-- Compact style argument -->
+<div style="left: 50%;
+            bottom: 0"
+     class="absolute -translate-x-1/2 data-tag data-tag--lg data-tag--borders tint-green text-24 h-36">
+  style is first arg
+</div>
+
+<div class="flex flex-col items-center absolute z-10 {% if title|length > 30 %}w-4/5{% else %}w-1/2{% endif %}"
+     style="top:60%;
+            transform:translate(0,-50%)">
+  style is second arg
+</div>
+
+<div class="flex flex-col items-center absolute z-10 {% if title|length > 30 %}w-4/5{% else %}w-1/2{% endif %}"
+     style="top:60%;
+            transform:translate(0,-50%)"
+     id="dfff">
+  style is middle arg
+</div>
+
+<div style="top:60%;
+            transform:translate(0,-50%)">
+</div>
+
+<div class="absolute right-0 bg-blue-020 rounded-full"
+     style="height: 585px;
+            width: 585px;
+            filter: blur(86px);
+            top: 153px">Big multiline style arg</div>
+
+<div style="top:90%;
+            transform:translate(0,-50%)">
+  <div style="top:80%;
+              transform:translate(0,-50%)">
+    <div style="top:70%;
+                transform:translate(0,-50%)">
+      Nested divs with multiline style attrs
+    </div>
+  </div>
+</div>
+
+<div
+        style="   color : red;
+            display    :inline "
+></div>
+<div
+        style="   color : red;
+            display    :inline; height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0; "
+></div>
+
+
+<div style="top:60%;
+     transform:translate(0,-50%)">
+  <div style="top:60%;
+transform:translate(0,-50%)">
+    <div style="top:60%;
+                 transform:translate(0,-50%)">
+      Nested divs with odd off
+    </div>
+  </div>
+</div>
+
+<!-- Preserve multiline style argument -->
+<div
+  style="
+    color: red;
+    display: inline;
+    height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  "
+></div>

--- a/markup_fmt/tests/fmt/html/attributes/style.snap
+++ b/markup_fmt/tests/fmt/html/attributes/style.snap
@@ -1,50 +1,59 @@
 ---
 source: markup_fmt/tests/fmt.rs
 ---
-<div style="
+<div
+  style="
+         
+         color:
+         #fFf
+         
+         "
+>
+</div>
 
-color:
-#fFf
-
-"></div>
-
-<div style=" "></div>
+<div style=""></div>
 <div style></div>
 
 <div
   style="
-
-all: initial;display: block;
-contain: content;text-align: center;
-
-
-
-background: linear-gradient(to left, hotpink, #FFF00F, #ccc, hsla(240, 100%, 50%, .05), transparent);
-background: linear-gradient(to left, hsla(240, 100%, 50%, .05), red);
-max-width: 500px;margin: 0 auto;
-border-radius: 8px;transition: transform .2s ease-out;
-
-"
+         
+         all: initial;display: block;
+         contain: content;text-align: center;
+         
+         
+         
+         background: linear-gradient(to left, hotpink, #FFF00F, #ccc, hsla(240, 100%, 50%, .05), transparent);
+         background: linear-gradient(to left, hsla(240, 100%, 50%, .05), red);
+         max-width: 500px;margin: 0 auto;
+         border-radius: 8px;transition: transform .2s ease-out;
+         
+         "
 >
 </div>
 
 <div
   style="
-background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transparent);
-"
+         background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transparent);
+         "
 >
 </div>
 
-<div style="   color : red;
-            display    :inline "></div>
+<div
+  style="color : red;
+         display    :inline "
+>
+</div>
 
-<div style="  
-
-color: green;
-
-display: inline 
-
-"></div>
+<div
+  style="
+         
+         color: green;
+         
+         display: inline 
+         
+         "
+>
+</div>
 
 <div
   attribute-1
@@ -72,7 +81,7 @@ display: inline
 <!-- Compact style argument -->
 <div
   style="left: 50%;
-            bottom: 0"
+         bottom: 0"
   class="absolute -translate-x-1/2 data-tag data-tag--lg data-tag--borders tint-green text-24 h-36"
 >
   style is first arg
@@ -81,7 +90,7 @@ display: inline
 <div
   class="flex flex-col items-center absolute z-10 {% if title|length > 30 %}w-4/5{% else %}w-1/2{% endif %}"
   style="top:60%;
-            transform:translate(0,-50%)"
+         transform:translate(0,-50%)"
 >
   style is second arg
 </div>
@@ -89,55 +98,73 @@ display: inline
 <div
   class="flex flex-col items-center absolute z-10 {% if title|length > 30 %}w-4/5{% else %}w-1/2{% endif %}"
   style="top:60%;
-            transform:translate(0,-50%)"
+         transform:translate(0,-50%)"
   id="dfff"
 >
   style is middle arg
 </div>
 
-<div style="top:60%;
-            transform:translate(0,-50%)"></div>
+<div
+  style="top:60%;
+         transform:translate(0,-50%)"
+>
+</div>
 
 <div
   class="absolute right-0 bg-blue-020 rounded-full"
   style="height: 585px;
-            width: 585px;
-            filter: blur(86px);
-            top: 153px"
+         width: 585px;
+         filter: blur(86px);
+         top: 153px"
 >
   Big multiline style arg
 </div>
 
-<div style="top:90%;
-            transform:translate(0,-50%)">
-  <div style="top:80%;
-              transform:translate(0,-50%)">
-    <div style="top:70%;
-                transform:translate(0,-50%)">
+<div
+  style="top:90%;
+         transform:translate(0,-50%)"
+>
+  <div
+    style="top:80%;
+           transform:translate(0,-50%)"
+  >
+    <div
+      style="top:70%;
+             transform:translate(0,-50%)"
+    >
       Nested divs with multiline style attrs
     </div>
   </div>
 </div>
 
-<div style="   color : red;
-            display    :inline "></div>
 <div
-  style="   color : red;
-            display    :inline; height: auto;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0; "
+  style="color : red;
+         display    :inline "
+>
+</div>
+<div
+  style="color : red;
+         display    :inline; height: auto;
+         position: absolute;
+         top: 0;
+         left: 0;
+         right: 0;
+         bottom: 0; "
 >
 </div>
 
-<div style="top:60%;
-     transform:translate(0,-50%)">
-  <div style="top:60%;
-transform:translate(0,-50%)">
-    <div style="top:60%;
-                 transform:translate(0,-50%)">
+<div
+  style="top:60%;
+         transform:translate(0,-50%)"
+>
+  <div
+    style="top:60%;
+           transform:translate(0,-50%)"
+  >
+    <div
+      style="top:60%;
+             transform:translate(0,-50%)"
+    >
       Nested divs with odd off
     </div>
   </div>
@@ -146,14 +173,14 @@ transform:translate(0,-50%)">
 <!-- Preserve multiline style argument -->
 <div
   style="
-    color: red;
-    display: inline;
-    height: auto;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  "
+         color: red;
+         display: inline;
+         height: auto;
+         position: absolute;
+         top: 0;
+         left: 0;
+         right: 0;
+         bottom: 0;
+         "
 >
 </div>

--- a/markup_fmt/tests/fmt/html/attributes/style.snap
+++ b/markup_fmt/tests/fmt/html/attributes/style.snap
@@ -68,3 +68,92 @@ display: inline
 <div style="{{ ...styles }}"></div>
 
 <div style="color: red; {{ otherStyles }}"></div>
+
+<!-- Compact style argument -->
+<div
+  style="left: 50%;
+            bottom: 0"
+  class="absolute -translate-x-1/2 data-tag data-tag--lg data-tag--borders tint-green text-24 h-36"
+>
+  style is first arg
+</div>
+
+<div
+  class="flex flex-col items-center absolute z-10 {% if title|length > 30 %}w-4/5{% else %}w-1/2{% endif %}"
+  style="top:60%;
+            transform:translate(0,-50%)"
+>
+  style is second arg
+</div>
+
+<div
+  class="flex flex-col items-center absolute z-10 {% if title|length > 30 %}w-4/5{% else %}w-1/2{% endif %}"
+  style="top:60%;
+            transform:translate(0,-50%)"
+  id="dfff"
+>
+  style is middle arg
+</div>
+
+<div style="top:60%;
+            transform:translate(0,-50%)"></div>
+
+<div
+  class="absolute right-0 bg-blue-020 rounded-full"
+  style="height: 585px;
+            width: 585px;
+            filter: blur(86px);
+            top: 153px"
+>
+  Big multiline style arg
+</div>
+
+<div style="top:90%;
+            transform:translate(0,-50%)">
+  <div style="top:80%;
+              transform:translate(0,-50%)">
+    <div style="top:70%;
+                transform:translate(0,-50%)">
+      Nested divs with multiline style attrs
+    </div>
+  </div>
+</div>
+
+<div style="   color : red;
+            display    :inline "></div>
+<div
+  style="   color : red;
+            display    :inline; height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0; "
+>
+</div>
+
+<div style="top:60%;
+     transform:translate(0,-50%)">
+  <div style="top:60%;
+transform:translate(0,-50%)">
+    <div style="top:60%;
+                 transform:translate(0,-50%)">
+      Nested divs with odd off
+    </div>
+  </div>
+</div>
+
+<!-- Preserve multiline style argument -->
+<div
+  style="
+    color: red;
+    display: inline;
+    height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  "
+>
+</div>

--- a/markup_fmt/tests/fmt/html/attributes/style.snap
+++ b/markup_fmt/tests/fmt/html/attributes/style.snap
@@ -3,11 +3,11 @@ source: markup_fmt/tests/fmt.rs
 ---
 <div
   style="
-         
-         color:
-         #fFf
-         
-         "
+  
+    color:
+    #fFf
+  
+  "
 >
 </div>
 
@@ -16,25 +16,25 @@ source: markup_fmt/tests/fmt.rs
 
 <div
   style="
-         
-         all: initial;display: block;
-         contain: content;text-align: center;
-         
-         
-         
-         background: linear-gradient(to left, hotpink, #FFF00F, #ccc, hsla(240, 100%, 50%, .05), transparent);
-         background: linear-gradient(to left, hsla(240, 100%, 50%, .05), red);
-         max-width: 500px;margin: 0 auto;
-         border-radius: 8px;transition: transform .2s ease-out;
-         
-         "
+  
+    all: initial;display: block;
+    contain: content;text-align: center;
+  
+  
+  
+    background: linear-gradient(to left, hotpink, #FFF00F, #ccc, hsla(240, 100%, 50%, .05), transparent);
+    background: linear-gradient(to left, hsla(240, 100%, 50%, .05), red);
+    max-width: 500px;margin: 0 auto;
+    border-radius: 8px;transition: transform .2s ease-out;
+  
+  "
 >
 </div>
 
 <div
   style="
-         background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transparent);
-         "
+    background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transparent);
+  "
 >
 </div>
 
@@ -46,12 +46,12 @@ source: markup_fmt/tests/fmt.rs
 
 <div
   style="
-         
-         color: green;
-         
-         display: inline 
-         
-         "
+  
+    color: green;
+  
+    display: inline 
+  
+  "
 >
 </div>
 
@@ -173,14 +173,14 @@ source: markup_fmt/tests/fmt.rs
 <!-- Preserve multiline style argument -->
 <div
   style="
-         color: red;
-         display: inline;
-         height: auto;
-         position: absolute;
-         top: 0;
-         left: 0;
-         right: 0;
-         bottom: 0;
-         "
+    color: red;
+    display: inline;
+    height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  "
 >
 </div>


### PR DESCRIPTION
Hi!

This mostly fix the issue I currently have with multiline `style` attribute getting weirdly indented.

```html
<div class="ds-flex ds-flex-col ds-items-center ds-absolute ds-z-10 {% if title|length > 30 %}ds-w-4/5{% else %}ds-w-1/2{% endif %}"
     style="top:60%;
            transform:translate(0,-50%)">
</div>
```
is changed to
```html
<div
  class="ds-flex ds-flex-col ds-items-center ds-absolute ds-z-10 {% if title|length > 30 %}ds-w-4/5{% else %}ds-w-1/2{% endif %}"
  style="top:60%;
            transform:translate(0,-50%)"
>
</div>
```
Every time some kind of wrapping occurred, and the attr value is on multiple lines, the indent is not preserved.

I also tried to avoid disruption for another common style of multiline style attribute ([Prettier for ex](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAJgSwG4AIwA2AhgM4kC8AOiOiQLQBmBcAHrrY8y3ZAe-ZngBbemATwATvzpEARiQgEArvGkAvOgEYADLmABSXJga4Yg5gB9mUAOYwAFrgB8uAMy79AXw4B3OgBYAegBWA1w4AhI4XC9fLUCAJjCELBMvakooXGzskhgAT2YqEBgIAAckADZtfQBuTJzGpuYGGCRcYJr6rKbe3ggJdok4dG7e3pgJIigSBgGhJEnpkmJ4AAptABo6Tv0ASjHxxqWZuYkFk5Wida2dmoOGo5zLs4upmdW4De3dveonTKoQJYbBOECbEDlMzQEjIUBECQSCA+AAKCIQsJQRAIPiI+VhENkUzAAGs4DAAMpEIRwAAymCgcGQDGxUUJxLJlLKRDADJsyEmSjgEKiQkwAokQohrDKcAkmBpsGxABU5VAEZg4JiWZFhSASHzmABFJQQeDM1l6gBWJBYFMNcBNZqZSB1bJAAEdTfAUUiypiQKQ6IyRiNwSUppgCHyAMIQIRCIjIQMEAjhg22ZgAQRgk0wshUcBRcvpjIlUpA9hgQgIAHV7IItdyxBSMYIcIJ8smwGRw9ghQBJKDocQUsDysowLPDikFZgW3UQspIqK1qZlZPLrVy7BMiEMqISGC+og2RML93ciSH5NVmvh5cMmC1zDoBzIACclQhwy9mGGJ5nkmrqWhCMByC+b72MgCQQkoUTKnI2qgSAcBCLIIwjugtLTDYSinnAABi8zXGYtjJkQKgQCAnieEAA))
```html
<div
    class="ds-flex ds-flex-col ds-items-center ds-absolute ds-z-10 {% if title|length > 30 %}ds-w-4/5{% else %}ds-w-1/2{% endif %}"
    style="
        top: 60%;
        transform: translate(0, -50%);
    "
></div>
```

---
**I'm marking this as draft because it's not actually addressing the problem, it's a workaround. I was not able to find the offset between the initial indent level and the formatted indent level :/ .**

I think the issue could probably be solved by proper value formatting using malva maybe ?
This would be awesome:
- we could detect invalid css directive at parsing time and raise errors
- formatting would be consistant, using a single line when possible, or multiline (with configurable style maybe?) 

