### PR TITLE
Normalize `accept` HTML attribute value as a comma separated string

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -883,6 +883,13 @@ impl<'s> DocGen<'s> for NativeAttribute<'s> {
             docs.push(quote.clone());
             if self.name.eq_ignore_ascii_case("class") {
                 docs.push(Doc::text(value.split_ascii_whitespace().join(" ")));
+            } else if self.name.eq_ignore_ascii_case("accept")
+                && state
+                    .current_tag_name
+                    .map(|name| name.eq_ignore_ascii_case("input"))
+                    .unwrap_or_default()
+            {
+                docs.push(Doc::text(value.split(',').map(|s| s.trim()).join(", ")));
             } else {
                 docs.extend(reflow_owned(&value));
             }

--- a/markup_fmt/tests/fmt/html/attributes/accept.html
+++ b/markup_fmt/tests/fmt/html/attributes/accept.html
@@ -1,0 +1,31 @@
+<label for="movie">Choose a movie to upload:</label>
+
+<input type="file" id="movie" name="movie" accept="video/*" />
+
+<label for="poster">Choose a poster:</label>
+
+<input type="file" id="poster" name="poster" accept="image/png, image/jpeg" />
+
+<input type="file" accept=".jpg,.jpeg,.png">
+<input type="file" accept="text/html,application/zip">
+<input type="file" accept="text/html ">
+<input type="file" accept=" ">
+
+<input type="file" accept=" image/gif
+                               , image/jpeg ">
+
+<input type="file" accept="
+
+
+ image/gif
+                               ,
+
+
+                               image/jpeg
+
+">
+
+
+
+<input type="file" accept="image/gif  image/jpeg">
+<div type="file" name="poster" accept="      image/png,    image/jpeg    " ></div>

--- a/markup_fmt/tests/fmt/html/attributes/accept.snap
+++ b/markup_fmt/tests/fmt/html/attributes/accept.snap
@@ -1,0 +1,23 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<label for="movie">Choose a movie to upload:</label>
+
+<input type="file" id="movie" name="movie" accept="video/*" />
+
+<label for="poster">Choose a poster:</label>
+
+<input type="file" id="poster" name="poster" accept="image/png, image/jpeg" />
+
+<input type="file" accept=".jpg, .jpeg, .png">
+<input type="file" accept="text/html, application/zip">
+<input type="file" accept="text/html">
+<input type="file" accept="">
+
+<input type="file" accept="image/gif, image/jpeg">
+
+<input type="file" accept="image/gif, image/jpeg">
+
+<input type="file" accept="image/gif  image/jpeg">
+<div type="file" name="poster" accept="      image/png,    image/jpeg    ">
+</div>


### PR DESCRIPTION
The html `accept` attribute [expect a comma separated list of string](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept). 
This is easy to normalize the same way we normalize `class` as a space-separated list of string so I went for it.

This could possibly be expanded (`coords` on `area` should also be a comma separated list **[but with no whitespaces](https://html.spec.whatwg.org/multipage/image-maps.html#attr-area-coords)**). Let me know if you want me to expand it to the `coords` case (or any other you have in mind).

```diff
-<input type="file" accept=" image/gif
-                               , image/jpeg ">
+<input type="file" accept="image/gif, image/jpeg">
```