### PR TITLE
Update `NON_WS_SENSITIVE_TAGS` list

### DIFF
--- a/dprint_plugin/tests/integration/biome/quotes.vue.snap
+++ b/dprint_plugin/tests/integration/biome/quotes.vue.snap
@@ -7,7 +7,8 @@ source: dprint_plugin/tests/integration.rs
 
   <button
     @click="(content += '{&quot;hello&quot;: &quot;I\'m a button!&quot;}')"
-  ></button>
+  >
+  </button>
 
   <input :value='""'>
   <input :value='""'>

--- a/dprint_plugin/tests/integration/dprint_ts/quotes.vue.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/quotes.vue.snap
@@ -5,9 +5,8 @@ source: dprint_plugin/tests/integration.rs
   <div v-if="label = 'a'"></div>
   <div v-if="label = 'a'"></div>
 
-  <button
-    @click="content += '{&quot;hello&quot;: &quot;I\'m a button!&quot;}'"
-  ></button>
+  <button @click="content += '{&quot;hello&quot;: &quot;I\'m a button!&quot;}'">
+  </button>
 
   <input :value="''">
   <input :value="''">

--- a/markup_fmt/src/helpers.rs
+++ b/markup_fmt/src/helpers.rs
@@ -4,10 +4,13 @@ pub(crate) fn is_component(name: &str) -> bool {
     name.contains('-') || name.contains(|c: char| c.is_ascii_uppercase())
 }
 
-static NON_WS_SENSITIVE_TAGS: [&str; 69] = [
+static NON_WS_SENSITIVE_TAGS: [&str; 74] = [
     "address",
     "blockquote",
+    "button",
+    "caption",
     "center",
+    "colgroup",
     "dialog",
     "div",
     "figure",
@@ -25,6 +28,7 @@ static NON_WS_SENSITIVE_TAGS: [&str; 69] = [
     "p",
     "plaintext",
     "pre",
+    "progress",
     "search",
     "object",
     "details",
@@ -37,6 +41,7 @@ static NON_WS_SENSITIVE_TAGS: [&str; 69] = [
     "head",
     "link",
     "meta",
+    "meter",
     "noembed",
     "noframes",
     "param",

--- a/markup_fmt/tests/fmt/html/attributes/boolean.snap
+++ b/markup_fmt/tests/fmt/html/attributes/boolean.snap
@@ -5,24 +5,33 @@ source: markup_fmt/tests/fmt.rs
 <button type="submit" disabled>This is valid.</button>
 <button type="submit" disabled="">This is valid.</button>
 <button type="submit" disabled="disabled">This is valid.</button>
-<button type="submit" disabled="true"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="true"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="true"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="false"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="false"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="false"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="hahah"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="hahah"
->This is valid. This will be disabled.</button>
-<button type="submit" disabled="hahah"
->This is valid. This will be disabled.</button>
+<button type="submit" disabled="true">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="true">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="true">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="false">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="false">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="false">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="hahah">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="hahah">
+  This is valid. This will be disabled.
+</button>
+<button type="submit" disabled="hahah">
+  This is valid. This will be disabled.
+</button>
 <input type="checkbox" checked disabled name="cheese">
 <input type="checkbox" checked="checked" disabled="disabled" name="cheese">
 <input type="checkbox" checked="" disabled="" name="cheese">

--- a/markup_fmt/tests/fmt/html/tags/menu.small-print-width.snap
+++ b/markup_fmt/tests/fmt/html/tags/menu.small-print-width.snap
@@ -7,7 +7,9 @@ source: markup_fmt/tests/fmt.rs
   >
     <button
       onclick="copy()"
-    >Copy</button
+    >
+      Copy
+    </button
     >
   </li
   >
@@ -15,7 +17,9 @@ source: markup_fmt/tests/fmt.rs
   >
     <button
       onclick="cut()"
-    >Cut</button
+    >
+      Cut
+    </button
     >
   </li
   >
@@ -23,7 +27,9 @@ source: markup_fmt/tests/fmt.rs
   >
     <button
       onclick="paste()"
-    >Paste</button
+    >
+      Paste
+    </button
     >
   </li
   >

--- a/markup_fmt/tests/fmt/html/tags/search.small-print-width.snap
+++ b/markup_fmt/tests/fmt/html/tags/search.small-print-width.snap
@@ -58,7 +58,9 @@ source: markup_fmt/tests/fmt.rs
           >
           <button
             type="submit"
-          >Go!</button
+          >
+            Go!
+          </button
           >
         </form
         >

--- a/markup_fmt/tests/fmt/html/tags/tags.default.snap
+++ b/markup_fmt/tests/fmt/html/tags/tags.default.snap
@@ -133,14 +133,16 @@ source: markup_fmt/tests/fmt.rs
 <button xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>12345678901234567890</button>
 <br /><br />
 
-<button bind-disabled="isUnchanged" on-click="onSave($event)"
->Disabled Cancel</button>
+<button bind-disabled="isUnchanged" on-click="onSave($event)">
+  Disabled Cancel
+</button>
 <br /><br />
 <button xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>12345678901234567890</button>
 <br /><br />
 
-<button bind-disabled="isUnchanged" on-click="onSave($event)"
->Disabled Cancel</button>
+<button bind-disabled="isUnchanged" on-click="onSave($event)">
+  Disabled Cancel
+</button>
 <br /><br />
 <p>
   "<span [innerHTML]="title"></span>" is the <i>property bound</i> title.

--- a/markup_fmt/tests/fmt/html/tags/tags.small-print-width.snap
+++ b/markup_fmt/tests/fmt/html/tags/tags.small-print-width.snap
@@ -374,7 +374,9 @@ source: markup_fmt/tests/fmt.rs
 />
 <button
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
->12345678901234567890</button
+>
+  12345678901234567890
+</button
 >
 <br
 /><br
@@ -383,15 +385,19 @@ source: markup_fmt/tests/fmt.rs
 <button
   bind-disabled="isUnchanged"
   on-click="onSave($event)"
->Disabled
-  Cancel</button
+>
+  Disabled
+  Cancel
+</button
 >
 <br
 /><br
 />
 <button
   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
->12345678901234567890</button
+>
+  12345678901234567890
+</button
 >
 <br
 /><br
@@ -400,8 +406,10 @@ source: markup_fmt/tests/fmt.rs
 <button
   bind-disabled="isUnchanged"
   on-click="onSave($event)"
->Disabled
-  Cancel</button
+>
+  Disabled
+  Cancel
+</button
 >
 <br
 /><br

--- a/markup_fmt/tests/fmt/html/tags/tags2.default.snap
+++ b/markup_fmt/tests/fmt/html/tags/tags2.default.snap
@@ -26,14 +26,8 @@ source: markup_fmt/tests/fmt.rs
 </div>
 
 <div>
-  before<meter
-    min="0"
-    max="1"
-    low=".4"
-    high=".7"
-    optimum=".5"
-    value=".2"
-  ></meter>after
+  before<meter min="0" max="1" low=".4" high=".7" optimum=".5" value=".2">
+  </meter>after
 </div>
 
 <div>before<progress value=".5" max="1"></progress>after</div>

--- a/markup_fmt/tests/fmt/html/tags/tags2.small-print-width.snap
+++ b/markup_fmt/tests/fmt/html/tags/tags2.small-print-width.snap
@@ -81,7 +81,8 @@ source: markup_fmt/tests/fmt.rs
     high=".7"
     optimum=".5"
     value=".2"
-  ></meter
+  >
+  </meter
   >after
 </div
 >
@@ -91,7 +92,8 @@ source: markup_fmt/tests/fmt.rs
   before<progress
     value=".5"
     max="1"
-  ></progress
+  >
+  </progress
   >after
 </div
 >

--- a/markup_fmt/tests/fmt/html/whitespace/display-inline-block.snap
+++ b/markup_fmt/tests/fmt/html/whitespace/display-inline-block.snap
@@ -1,22 +1,27 @@
 ---
 source: markup_fmt/tests/fmt.rs
 ---
-<button>Click here! Click here! Click here! Click here! Click here! Click
-  here!</button>
+<button>
+  Click here! Click here! Click here! Click here! Click here! Click here!
+</button>
 <button>
   Click here! Click here! Click here! Click here! Click here! Click here!
 </button>
 <div>
-  <button>Click here! Click here! Click here! Click here! Click here! Click
-    here!</button>
-  <button>Click here! Click here! Click here! Click here! Click here! Click
-    here!</button>
+  <button>
+    Click here! Click here! Click here! Click here! Click here! Click here!
+  </button>
+  <button>
+    Click here! Click here! Click here! Click here! Click here! Click here!
+  </button>
 </div>
 <div>
-  <button>Click here! Click here! Click here! Click here! Click here! Click
-    here!</button>
-  <button>Click here! Click here! Click here! Click here! Click here! Click
-    here!</button>
+  <button>
+    Click here! Click here! Click here! Click here! Click here! Click here!
+  </button>
+  <button>
+    Click here! Click here! Click here! Click here! Click here! Click here!
+  </button>
 </div>
 <video src="brave.webm">
   <track kind="subtitles" src="brave.en.vtt" srclang="en" label="English">

--- a/markup_fmt/tests/fmt/vue/quotes/mixed.double.snap
+++ b/markup_fmt/tests/fmt/vue/quotes/mixed.double.snap
@@ -2,7 +2,6 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <template>
-  <button
-    @click="content += '{&quot;hello&quot;: &quot;I\'m a button!&quot;}'"
-  ></button>
+  <button @click="content += '{&quot;hello&quot;: &quot;I\'m a button!&quot;}'">
+  </button>
 </template>

--- a/markup_fmt/tests/fmt/vue/quotes/mixed.single.snap
+++ b/markup_fmt/tests/fmt/vue/quotes/mixed.single.snap
@@ -2,7 +2,6 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <template>
-  <button
-    @click='content += &#x27;{"hello": "I\&#x27;m a button!"}&#x27;'
-  ></button>
+  <button @click='content += &#x27;{"hello": "I\&#x27;m a button!"}&#x27;'>
+  </button>
 </template>


### PR DESCRIPTION
This add a few entries to `NON_WS_SENSITIVE_TAGS` which I believe were missing.

I found them because I was surprised of the way buttons were formatted in my codebase and then did further digging (using [html-ua-styles](https://github.com/prettier/html-ua-styles)) to find the others.

- `button`:  default display is `inline-block`
- `caption`: default display is `table-caption`
- `colgroup`: default display is `table-column-group`
- `progress`: default display is `inline-block`
- `meter`: default display is `inline-block`
