### PR TITLE
feat: support for JSON-LD in <script> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dprint config add g-plane/malva
 dprint config add typescript
 ```
 
-If you also want to format JSON in `<script>` tag whose `"type"` is `"importmap"` or `"application/json"`,
+If you also want to format JSON in `<script>` tag whose `"type"` is `"importmap"`, `"application/json"`, or `"application/ld+json"`,
 you can add dprint-plugin-json:
 
 ```bash

--- a/dprint_plugin/tests/integration/biome/json.html.snap
+++ b/dprint_plugin/tests/integration/biome/json.html.snap
@@ -14,5 +14,8 @@ source: dprint_plugin/tests/integration.rs
     <script type="application/json">
     { "ssrData": { "items": [1, 2, 3] } }
     </script>
+    <script type="application/ld+json">
+    { "@context": "https://schema.org" }
+    </script>
   </body>
 </html>

--- a/dprint_plugin/tests/integration/dprint_ts/json.html.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/json.html.snap
@@ -14,5 +14,8 @@ source: dprint_plugin/tests/integration.rs
     <script type="application/json">
     { "ssrData": { "items": [1, 2, 3] } }
     </script>
+    <script type="application/ld+json">
+    { "@context": "https://schema.org" }
+    </script>
   </body>
 </html>

--- a/dprint_plugin/tests/integration/json.html
+++ b/dprint_plugin/tests/integration/json.html
@@ -6,5 +6,8 @@
     <script type="application/json">
     {"ssrData":{"items":[1,2,3]}}
     </script>
+    <script type="application/ld+json">
+        {"@context": "https://schema.org"}
+    </script>
   </body>
 </html>

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -558,7 +558,7 @@ impl<'s> DocGen<'s> for Element<'s> {
                                 && native_attr
                                     .value
                                     .map(|(value, _)| {
-                                        value == "importmap" || value == "application/json"
+                                        value == "importmap" || value == "application/json" || value == "application/ld+json"
                                     })
                                     .unwrap_or_default()
                         } else {


### PR DESCRIPTION
JSON-LD is used for markup of structured data.
Therefore, it should be formatted as JSON when using `application/ld+json`.

https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data