### PR TITLE
fix(dprint_plugin): modify the line_width to avoid the style tag problem

### DIFF
--- a/dprint_plugin/src/config.rs
+++ b/dprint_plugin/src/config.rs
@@ -14,7 +14,7 @@ pub(crate) fn resolve_config(
             print_width: get_value(
                 &mut config,
                 "printWidth",
-                global_config.line_width.unwrap_or(80),
+                global_config.line_width.unwrap_or(u32::MAX),
                 &mut diagnostics,
             ) as usize,
             use_tabs: get_value(


### PR DESCRIPTION
fix: modify the line_width value to avoid the style tag problem
This PR fix #71.