### PR TITLE
fix: Fix support for Svelte 5 snippet blocks

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1319,6 +1319,7 @@ impl<'s> DocGen<'s> for SvelteSnippetBlock<'s> {
                 ctx,
                 state,
             ))
+            .append(Doc::text("{/snippet}"))
     }
 }
 


### PR DESCRIPTION
Improves upon #68. I was happy to see that PR, but `markup_fmt v0.15.1` still had problems with parsing Svelte 5 snippet blocks when used in combination with `typescript 0.93.1`:

```
Unexpected token `/`. Expected identifier, string literal, numeric literal or [ for the computed key at file:///...MyComponent.svelte#.tsx:352:10

        <>{/snippet}</>
```

I didn't investigate the problem carefully, but I think this has something to do with the fact that the parser was treating the closing `{/snippet}` tag as text instead of consuming it and re-emitting it in the printer. Maybe this was intentional, since copying the above `{/key}` parsing logic was the obvious move I did. Perhaps @bartlomieju could comment.

This PR also fixes a typo (`ExpectSvelteIfBlock` -> `ExpectSvelteSnippetBlock`) that improves error reporting.