### PR TITLE
fix: fix angular control block after `@for`

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -206,31 +206,29 @@ impl<'s> Parser<'s> {
         let children = self.parse_angular_control_flow_children()?;
 
         let mut empty = None;
-        'empty: {
-            let mut chars = self.chars.clone();
-            'peek: loop {
-                match chars.next() {
-                    Some((_, c)) if c.is_ascii_whitespace() => continue 'peek,
-                    Some((_, '@')) => {
+        let mut chars = self.chars.clone();
+        'peek: loop {
+            match chars.next() {
+                Some((_, c)) if c.is_ascii_whitespace() => continue 'peek,
+                Some((_, '@')) => {
+                    if chars
+                        .next_if(|(_, c)| *c == 'e')
+                        .and_then(|_| chars.next_if(|(_, c)| *c == 'm'))
+                        .and_then(|_| chars.next_if(|(_, c)| *c == 'p'))
+                        .and_then(|_| chars.next_if(|(_, c)| *c == 't'))
+                        .and_then(|_| chars.next_if(|(_, c)| *c == 'y'))
+                        .is_some()
+                    {
                         self.chars = chars;
+                        self.skip_ws();
+                        empty = Some(self.parse_angular_control_flow_children()?);
+                        break 'peek;
+                    } else {
                         break 'peek;
                     }
-                    _ => break 'empty,
                 }
+                _ => break 'peek,
             }
-            if self
-                .chars
-                .next_if(|(_, c)| *c == 'e')
-                .and_then(|_| self.chars.next_if(|(_, c)| *c == 'm'))
-                .and_then(|_| self.chars.next_if(|(_, c)| *c == 'p'))
-                .and_then(|_| self.chars.next_if(|(_, c)| *c == 't'))
-                .and_then(|_| self.chars.next_if(|(_, c)| *c == 'y'))
-                .is_none()
-            {
-                return Err(self.emit_error(SyntaxErrorKind::ExpectKeyword("empty")));
-            }
-            self.skip_ws();
-            empty = Some(self.parse_angular_control_flow_children()?);
         }
 
         Ok(AngularFor {

--- a/markup_fmt/tests/fmt/angular/control-flow/for.component.html
+++ b/markup_fmt/tests/fmt/angular/control-flow/for.component.html
@@ -19,3 +19,12 @@
   @for ( item of items; track item){
   }
 </div>
+
+<div>
+  @for ( item of items; track item){
+  <li><strong>{{ item.name }}</strong></li>
+  }
+@for ( item of items; track item){
+<li><strong>{{item.name}}</strong></li>
+  }
+</div>

--- a/markup_fmt/tests/fmt/angular/control-flow/for.component.snap
+++ b/markup_fmt/tests/fmt/angular/control-flow/for.component.snap
@@ -20,3 +20,12 @@ source: markup_fmt/tests/fmt.rs
 <div>
   @for (item of items; track item) { }
 </div>
+
+<div>
+  @for (item of items; track item) {
+    <li><strong>{{ item.name }}</strong></li>
+  }
+  @for (item of items; track item) {
+    <li><strong>{{ item.name }}</strong></li>
+  }
+</div>


### PR DESCRIPTION
For angular `@for` control blocks the subsequent `@empty` is optional ([doc](https://angular.dev/guide/templates/control-flow#providing-a-fallback-for-for-blocks-with-the-empty-block])) but it was being enforced as the next control block after a `@for`.

Tried to modify in alignment with how `parse_angular_if` was handling the optional subsequent control blocks.

Happy to fix up or or tweak as I didn't engage with too much of this code base when trying to fix this but it did resolve the errors I was getting when running on an Angular code base.

Output of added test cases without the code changes:
```
called `Result::unwrap()` on an `Err` value: "failed to format '.../markup_fmt/markup_fmt/tests/fmt/angular/control-flow/for.component.html': Syntax(SyntaxError { kind: ExpectKeyword(\"empty\"), pos: 467, line: 27, column: 3 })"
```