### PR TITLE
Fix `Jinja` set assignment

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -1287,10 +1287,10 @@ impl<'s> Parser<'s> {
                 | "autoescape"
                 | "embed"
                 | "with"
-                | "set"
                 | "trans"
                 | "raw"
-        ) {
+        ) || matches!(tag_name, "set") && !&first_tag.content.contains('=')
+        {
             let mut body = vec![JinjaTagOrChildren::Tag(first_tag)];
 
             loop {

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -1289,7 +1289,7 @@ impl<'s> Parser<'s> {
                 | "with"
                 | "trans"
                 | "raw"
-        ) || matches!(tag_name, "set") && !&first_tag.content.contains('=')
+        ) || tag_name == "set" && !first_tag.content.contains('=')
         {
             let mut body = vec![JinjaTagOrChildren::Tag(first_tag)];
 

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -882,11 +882,24 @@ impl<'s> DocGen<'s> for JinjaTag<'s> {
             .strip_suffix('-')
             .map(|content| (content, "-"))
             .unwrap_or((content, ""));
-        Doc::text("{%")
+
+        let docs = Doc::text("{%")
             .append(Doc::text(prefix))
-            .append(Doc::line_or_space())
-            .append(Doc::text(content.trim()))
-            .nest(ctx.indent_width)
+            .append(Doc::line_or_space());
+
+        let docs = if content.trim().starts_with("set") {
+            if let Some((left, right)) = content.split_once('=') {
+                docs.append(Doc::text(left.trim()))
+                    .append(Doc::text(" = "))
+                    .append(Doc::text(right.trim()))
+            } else {
+                docs.append(Doc::text(content.trim()))
+            }
+        } else {
+            docs.append(Doc::text(content.trim()))
+        };
+
+        docs.nest(ctx.indent_width)
             .append(Doc::line_or_space())
             .append(Doc::text(suffix))
             .append(Doc::text("%}"))

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -886,7 +886,6 @@ impl<'s> DocGen<'s> for JinjaTag<'s> {
         let docs = Doc::text("{%")
             .append(Doc::text(prefix))
             .append(Doc::line_or_space());
-
         let docs = if content.trim().starts_with("set") {
             if let Some((left, right)) = content.split_once('=') {
                 docs.append(Doc::text(left.trim()))
@@ -898,7 +897,6 @@ impl<'s> DocGen<'s> for JinjaTag<'s> {
         } else {
             docs.append(Doc::text(content.trim()))
         };
-
         docs.nest(ctx.indent_width)
             .append(Doc::line_or_space())
             .append(Doc::text(suffix))

--- a/markup_fmt/tests/fmt/jinja/single-tag/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/single-tag/fixture.jinja
@@ -1,4 +1,17 @@
+
 {% include "sidebar.html" without context %}
 {% include "sidebar.html" ignore missing %}
 {% import 'forms.html' as forms %}
 {%import 'forms.html' as forms%}
+
+{% set navigation = [('index.html', 'Index'), ('about.html', 'About')] %}
+{% set key, value = call_something() %}
+{% set iterated = false %}
+{% for item in seq %}
+{{ item }}
+{% set iterated = true %}
+{% endfor %}
+{% set ns = namespace(found=false) %}
+{% set ns.foo = 'bar' %}
+{% set pipe = joiner("|") %}
+{%set pipe=joiner("|")%}

--- a/markup_fmt/tests/fmt/jinja/single-tag/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/single-tag/fixture.jinja
@@ -1,4 +1,3 @@
-
 {% include "sidebar.html" without context %}
 {% include "sidebar.html" ignore missing %}
 {% import 'forms.html' as forms %}

--- a/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
@@ -16,4 +16,4 @@ snapshot_kind: text
 {% set ns = namespace(found=false) %}
 {% set ns.foo = 'bar' %}
 {% set pipe = joiner("|") %}
-{% set pipe=joiner("|") %}
+{% set pipe = joiner("|") %}

--- a/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
@@ -1,7 +1,19 @@
 ---
 source: markup_fmt/tests/fmt.rs
+snapshot_kind: text
 ---
 {% include "sidebar.html" without context %}
 {% include "sidebar.html" ignore missing %}
 {% import 'forms.html' as forms %}
 {% import 'forms.html' as forms %}
+
+{% set navigation = [('index.html', 'Index'), ('about.html', 'About')] %}
+{% set key, value = call_something() %}
+{% set iterated = false %}
+{% for item in seq %}
+  {{ item }} {% set iterated = true %}
+{% endfor %}
+{% set ns = namespace(found=false) %}
+{% set ns.foo = 'bar' %}
+{% set pipe = joiner("|") %}
+{% set pipe=joiner("|") %}


### PR DESCRIPTION
Fixes #93 

I went for a very similar approach to `parse_vento_tag_or_block` which I believe is sufficient because I don't think it's possible to have an equal sign inside the opening tag of a `set` block.

I've also expanded the scope a little in the last commit to format the equal sign with space around (it seems to be the preferred style from the jinja documentation). I can drop this one if your don't think is needed