### PR TITLE
Fix jinja interpolation in tag name causing parser to crash

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -2310,7 +2310,8 @@ impl<'s> Parser<'s> {
                             if is_tag_name_char(c)
                                 || c == '/'
                                 || c == '!'
-                                || c == '>' && matches!(self.language, Language::Astro) =>
+                                || c == '>' && matches!(self.language, Language::Astro)
+                                || c == '{' && matches!(self.language, Language::Jinja) =>
                         {
                             end = i;
                             break;

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.jinja
@@ -32,3 +32,7 @@
 <h{{ partial_tag_name }}a> Hello </h{{ partial_tag_name }}a>
 <h{{ partial_tag_name }}a  > Hello </h{{ partial_tag_name }}a  >
 <h{{ partial_tag_name }}a> very-very-very-very-very-very-very-very-very-long-title </h{{ partial_tag_name }}a>
+
+<{{ tag_name }}> Hello </{{ tag_name }}>
+<{{ tag_name }}  > Hello </{{ tag_name }}  >
+<{{ tag_name }}> very-very-very-very-very-very-very-very-very-long-title </{{ tag_name }}>

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.jinja
@@ -24,3 +24,11 @@
   {{ user.first_name }}
   {{ user.last_name }}!
 </span>
+
+<h{{ heading_level|default:2 }}> Hello </h{{ heading_level|default:2 }}>
+<h{{ heading_level|default:2 }}  > Hello </h{{ heading_level|default:2 }}  >
+<h{{ heading_level|default:2 }}> very-very-very-very-very-very-very-very-very-long-title </h{{ heading_level|default:2 }}>
+
+<h{{ partial_tag_name }}a> Hello </h{{ partial_tag_name }}a>
+<h{{ partial_tag_name }}a  > Hello </h{{ partial_tag_name }}a  >
+<h{{ partial_tag_name }}a> very-very-very-very-very-very-very-very-very-long-title </h{{ partial_tag_name }}a>

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
@@ -1,6 +1,5 @@
 ---
 source: markup_fmt/tests/fmt.rs
-snapshot_kind: text
 ---
 <div>
   {{ x }} {{ x }} {{ x }}

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
@@ -1,5 +1,6 @@
 ---
 source: markup_fmt/tests/fmt.rs
+snapshot_kind: text
 ---
 <div>
   {{ x }} {{ x }} {{ x }}
@@ -29,3 +30,15 @@ source: markup_fmt/tests/fmt.rs
   {{ user.first_name }}
   {{ user.last_name }}!
 </span>
+
+<h{{ heading_level|default:2 }}> Hello </h{{ heading_level|default:2 }}>
+<h{{ heading_level|default:2 }}> Hello </h{{ heading_level|default:2 }}>
+<h{{ heading_level|default:2 }}>
+  very-very-very-very-very-very-very-very-very-long-title
+</h{{ heading_level|default:2 }}>
+
+<h{{ partial_tag_name }}a> Hello </h{{ partial_tag_name }}a>
+<h{{ partial_tag_name }}a> Hello </h{{ partial_tag_name }}a>
+<h{{ partial_tag_name }}a>
+  very-very-very-very-very-very-very-very-very-long-title
+</h{{ partial_tag_name }}a>

--- a/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/interpolation/fixture.snap
@@ -42,3 +42,9 @@ snapshot_kind: text
 <h{{ partial_tag_name }}a>
   very-very-very-very-very-very-very-very-very-long-title
 </h{{ partial_tag_name }}a>
+
+<{{ tag_name }}> Hello </{{ tag_name }}>
+<{{ tag_name }}> Hello </{{ tag_name }}>
+<{{ tag_name }}>
+  very-very-very-very-very-very-very-very-very-long-title
+</{{ tag_name }}>

--- a/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
@@ -1,6 +1,5 @@
 ---
 source: markup_fmt/tests/fmt.rs
-snapshot_kind: text
 ---
 {% include "sidebar.html" without context %}
 {% include "sidebar.html" ignore missing %}


### PR DESCRIPTION
Hey!

This fixes 2 similar issues with Jinja interpolations inside html tag names causing `markup_fmt` to crash. 

1. With this snippet I get `syntax error 'expected close tag' at line 3, column 0` (see [playground](https://dprint.dev/playground/#code/DwCw3mAEIKYIYBMCWA7A5gfQDYwG4ywB8EYAzOAVywBcAuAJkgF8mA+AKEi8gBUlqc7YAHpwUWIlSYc+IiXJU6jFqyA/plugin/markup_fmt)):

```jinja
<h{{ heading_level|default:2 }}>
    Title
</h{{ heading_level|default:2 }}>
```

2. With this snippet, i get `syntax error 'expected tag name' at line 4, column 8` (See [playground](https://dprint.dev/playground/#code/DwEwlgbgfAUABAuwDey4BcCGBzA+gO0wFsBTOAX3NkRrgBUx0AbE+RYAelQxwOLMqxO4aEA/plugin/markup_fmt))

```jinja
<div>
  <{{ tag_name }}>
    Title
  </{{ tag_name }}>
</div>
```

Review commit per commit is recommended. It took me some time to find the fix in commit 2 and the helper function introduced in commit 3 aims at avoiding a similar pain next time.