### PR TITLE
Jinja Comments in html tag fail to parse

### DIFF
--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -61,8 +61,8 @@ pub enum AstroExprChild<'s> {
 pub enum Attribute<'s> {
     Astro(AstroAttribute<'s>),
     JinjaBlock(JinjaBlock<'s, Attribute<'s>>),
-    JinjaTag(JinjaTag<'s>),
     JinjaComment(JinjaComment<'s>),
+    JinjaTag(JinjaTag<'s>),
     Native(NativeAttribute<'s>),
     Svelte(SvelteAttribute<'s>),
     VentoTagOrBlock(NodeKind<'s>),

--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -62,6 +62,7 @@ pub enum Attribute<'s> {
     Astro(AstroAttribute<'s>),
     JinjaBlock(JinjaBlock<'s, Attribute<'s>>),
     JinjaTag(JinjaTag<'s>),
+    JinjaComment(JinjaComment<'s>),
     Native(NativeAttribute<'s>),
     Svelte(SvelteAttribute<'s>),
     VentoTagOrBlock(NodeKind<'s>),

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -687,10 +687,10 @@ impl<'s> Parser<'s> {
                 let result = if matches!(self.chars.peek(), Some((_, '{'))) {
                     let mut chars = self.chars.clone();
                     chars.next();
-                    if let Some((_, '{')) = chars.next() {
-                        self.parse_native_attr().map(Attribute::Native)
-                    } else {
-                        self.parse_jinja_tag_or_block(None, &mut Parser::parse_attr)
+                    match chars.next() {
+                        Some((_, '{')) => self.parse_native_attr().map(Attribute::Native),
+                        Some((_, '#')) => self.parse_jinja_comment().map(Attribute::JinjaComment),
+                        _ => self.parse_jinja_tag_or_block(None, &mut Parser::parse_attr),
                     }
                 } else {
                     self.parse_native_attr().map(Attribute::Native)

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -338,8 +338,8 @@ impl<'s> DocGen<'s> for Attribute<'s> {
             Attribute::VueDirective(vue_directive) => vue_directive.doc(ctx, state),
             Attribute::Astro(astro_attribute) => astro_attribute.doc(ctx, state),
             Attribute::JinjaBlock(jinja_block) => jinja_block.doc(ctx, state),
-            Attribute::JinjaTag(jinja_tag) => jinja_tag.doc(ctx, state),
             Attribute::JinjaComment(jinja_comment) => jinja_comment.doc(ctx, state),
+            Attribute::JinjaTag(jinja_tag) => jinja_tag.doc(ctx, state),
             Attribute::VentoTagOrBlock(vento_tag_or_block) => vento_tag_or_block.doc(ctx, state),
         }
     }

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -339,6 +339,7 @@ impl<'s> DocGen<'s> for Attribute<'s> {
             Attribute::Astro(astro_attribute) => astro_attribute.doc(ctx, state),
             Attribute::JinjaBlock(jinja_block) => jinja_block.doc(ctx, state),
             Attribute::JinjaTag(jinja_tag) => jinja_tag.doc(ctx, state),
+            Attribute::JinjaComment(jinja_comment) => jinja_comment.doc(ctx, state),
             Attribute::VentoTagOrBlock(vento_tag_or_block) => vento_tag_or_block.doc(ctx, state),
         }
     }

--- a/markup_fmt/tests/fmt/jinja/comments/fixture.disabled.snap
+++ b/markup_fmt/tests/fmt/jinja/comments/fixture.disabled.snap
@@ -16,3 +16,14 @@ source: markup_fmt/tests/fmt.rs
         #}
   </body>
 </html>
+
+<div
+  {#    resource index will be used for showing-hiding fields   #}
+  resource-index="{{ field.field.resource_index }}"
+  {# note: commented-out template because we no longer use this
+                {% for user in users %}
+                    ...
+                {% endfor %}
+            #}
+>
+</div>

--- a/markup_fmt/tests/fmt/jinja/comments/fixture.enabled.snap
+++ b/markup_fmt/tests/fmt/jinja/comments/fixture.enabled.snap
@@ -21,3 +21,15 @@ source: markup_fmt/tests/fmt.rs
     #}
   </body>
 </html>
+
+<div
+  {# resource index will be used for showing-hiding fields #}
+  resource-index="{{ field.field.resource_index }}"
+  {#
+    note: commented-out template because we no longer use this
+    {% for user in users %}
+        ...
+    {% endfor %}
+  #}
+>
+</div>

--- a/markup_fmt/tests/fmt/jinja/comments/fixture.jinja
+++ b/markup_fmt/tests/fmt/jinja/comments/fixture.jinja
@@ -13,3 +13,15 @@
         #}
     </body>
 </html>
+
+<div
+    {#    resource index will be used for showing-hiding fields   #}
+    resource-index="{{ field.field.resource_index }}"
+
+    {# note: commented-out template because we no longer use this
+                {% for user in users %}
+                    ...
+                {% endfor %}
+            #}
+>
+</div>


### PR DESCRIPTION
Currently `markup_fmt` cannot parse jinja comments if they are inside an html opening tag:

```jinja
<div
    {# resource index will be used for showing-hiding fields #}
    resource-index="{{ field.field.resource_index }}"
>
</div>
```

This PR adds what's needed for this to work.
Cheers from paris!

PS: Sry for the multiple prs, I've made a tool to do swiping tests on a lot of open source code and so I stumble on a few little bugs.