### PR TITLE
Link to relevant documentation page in `ast.rs`

### DIFF
--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -92,18 +92,30 @@ pub struct FrontMatter<'s> {
     pub start: usize,
 }
 
+/// A Jinja block containing nested Jinja tags or HTML elements.
+///
+/// See https://jinja.palletsprojects.com/en/stable/templates/#list-of-control-structures.
 pub struct JinjaBlock<'s, T> {
     pub body: Vec<JinjaTagOrChildren<'s, T>>,
 }
 
+/// A Jinja comment: `{# ... #}`.
+///
+/// See https://jinja.palletsprojects.com/en/stable/templates/#comments.
 pub struct JinjaComment<'s> {
     pub raw: &'s str,
 }
 
+/// A Jinja interpolation: `{{ ... }}`.
+///
+/// See https://jinja.palletsprojects.com/en/stable/templates/#expressions.
 pub struct JinjaInterpolation<'s> {
     pub expr: &'s str,
 }
 
+/// A Jinja tag: `{% ... %}`.
+///
+/// See https://jinja.palletsprojects.com/en/stable/templates/#list-of-control-structures.
 pub struct JinjaTag<'s> {
     pub content: &'s str,
 }

--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -63,7 +63,7 @@ pub struct AngularSwitchArm<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// An Astro attribute: `{expression}` / `name={expression}`.
+/// An Astro attribute: `{expression}` or `name={expression}`.
 ///
 /// See https://docs.astro.build/en/reference/astro-syntax/#dynamic-attributes.
 pub struct AstroAttribute<'s> {
@@ -80,15 +80,12 @@ pub struct AstroExpr<'s> {
     pub start: usize,
 }
 
-/// An enum representing children of an `AstroExpr`.
-///
 /// See https://docs.astro.build/en/core-concepts/astro-syntax/#dynamic-html.
 pub enum AstroExprChild<'s> {
     Script(&'s str),
     Template(Vec<Node<'s>>),
 }
 
-/// An enum representing different types of attributes in a document.
 pub enum Attribute<'s> {
     Astro(AstroAttribute<'s>),
     JinjaBlock(JinjaBlock<'s, Attribute<'s>>),
@@ -225,7 +222,7 @@ pub struct SvelteAtTag<'s> {
     pub expr: (&'s str, usize),
 }
 
-/// A Svelte attribute: `{expression}` / `name={expression}`.
+/// A Svelte attribute: `{expression}` or `name={expression}`.
 ///
 /// See https://svelte.dev/docs/svelte/basic-markup#Element-attributes.
 pub struct SvelteAttribute<'s> {

--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -1,9 +1,6 @@
-pub struct AngularElseIf<'s> {
-    pub expr: (&'s str, usize),
-    pub reference: Option<(&'s str, usize)>,
-    pub children: Vec<Node<'s>>,
-}
-
+/// An Angular for loop: `@for ( ... )`.
+///
+/// See https://angular.dev/api/core/@for.
 pub struct AngularFor<'s> {
     pub binding: (&'s str, usize),
     pub expr: (&'s str, usize),
@@ -13,6 +10,9 @@ pub struct AngularFor<'s> {
     pub empty: Option<Vec<Node<'s>>>,
 }
 
+/// An Angular conditional block: `@if ( condition )`.
+///
+/// See https://angular.dev/api/core/@if.
 pub struct AngularIf<'s> {
     pub expr: (&'s str, usize),
     pub reference: Option<(&'s str, usize)>,
@@ -21,43 +21,74 @@ pub struct AngularIf<'s> {
     pub else_children: Option<Vec<Node<'s>>>,
 }
 
+/// An Angular else-if block: `@else if ( condition )`.
+///
+/// See https://angular.dev/api/core/@if.
+pub struct AngularElseIf<'s> {
+    pub expr: (&'s str, usize),
+    pub reference: Option<(&'s str, usize)>,
+    pub children: Vec<Node<'s>>,
+}
+
+/// An Angular interpolation: `{{ expression }}`.
+///
+/// See https://angular.dev/guide/templates/binding#render-dynamic-text-with-text-interpolation.
 pub struct AngularInterpolation<'s> {
     pub expr: &'s str,
     pub start: usize,
 }
 
+/// An Angular let variable declaration: `@let name = expression`.
+///
+/// See https://angular.dev/api/core/@let.
 pub struct AngularLet<'s> {
     pub name: &'s str,
     pub expr: (&'s str, usize),
 }
 
+/// An Angular switch statement: `@switch (expression)`.
+///
+/// See https://angular.dev/api/core/@switch.
 pub struct AngularSwitch<'s> {
     pub expr: (&'s str, usize),
     pub arms: Vec<AngularSwitchArm<'s>>,
 }
 
+/// `@case` or `@default` arm of an `AngularSwitch`.
+///
+/// See https://angular.dev/api/core/@switch.
 pub struct AngularSwitchArm<'s> {
     pub keyword: &'static str,
     pub expr: Option<(&'s str, usize)>,
     pub children: Vec<Node<'s>>,
 }
 
+/// An Astro attribute: `{expression}` / `name={expression}`.
+///
+/// See https://docs.astro.build/en/reference/astro-syntax/#dynamic-attributes.
 pub struct AstroAttribute<'s> {
     pub name: Option<&'s str>,
     pub expr: (&'s str, usize),
 }
 
+/// An Astro expression block: `{...}`.
+///
+/// See https://docs.astro.build/en/reference/astro-syntax/#dynamic-html.
 pub struct AstroExpr<'s> {
     pub children: Vec<AstroExprChild<'s>>,
     pub has_line_comment: bool,
     pub start: usize,
 }
 
+/// An enum representing children of an `AstroExpr`.
+///
+/// See https://docs.astro.build/en/core-concepts/astro-syntax/#dynamic-html.
 pub enum AstroExprChild<'s> {
     Script(&'s str),
     Template(Vec<Node<'s>>),
 }
 
+/// An enum representing different types of attributes in a document.
 pub enum Attribute<'s> {
     Astro(AstroAttribute<'s>),
     JinjaBlock(JinjaBlock<'s, Attribute<'s>>),
@@ -69,15 +100,24 @@ pub enum Attribute<'s> {
     VueDirective(VueDirective<'s>),
 }
 
+/// A comment in HTML: `<!-- ... -->`.
+///
+/// See https://developer.mozilla.org/en-US/docs/Web/HTML/Comments
 pub struct Comment<'s> {
     pub raw: &'s str,
 }
 
+/// An HTML doctype declaration: `<!DOCTYPE ...>`.
+///
+/// See https://developer.mozilla.org/en-US/docs/Glossary/Doctype
 pub struct Doctype<'s> {
     pub keyword: &'s str,
     pub value: &'s str,
 }
 
+/// An HTML element with its attributes and children.
+///
+/// See https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 pub struct Element<'s> {
     pub tag_name: &'s str,
     pub attrs: Vec<Attribute<'s>>,
@@ -87,6 +127,9 @@ pub struct Element<'s> {
     pub void_element: bool,
 }
 
+/// Front matter content in a file, typically enclosed in `---`.
+///
+/// See https://docs.astro.build/en/guides/markdown-content/.
 pub struct FrontMatter<'s> {
     pub raw: &'s str,
     pub start: usize,
@@ -125,6 +168,9 @@ pub enum JinjaTagOrChildren<'s, T> {
     Children(Vec<T>),
 }
 
+/// A standard HTML attribute.
+///
+/// See https://developer.mozilla.org/en-US/docs/Glossary/Attribute
 pub struct NativeAttribute<'s> {
     pub name: &'s str,
     pub value: Option<(&'s str, usize)>,
@@ -171,16 +217,25 @@ pub struct Root<'s> {
     pub children: Vec<Node<'s>>,
 }
 
+/// A Svelte `@` tag: (`@render`, `@const`, etc).
+///
+/// See https://svelte.dev/docs/svelte/@render.
 pub struct SvelteAtTag<'s> {
     pub name: &'s str,
     pub expr: (&'s str, usize),
 }
 
+/// A Svelte attribute: `{expression}` / `name={expression}`.
+///
+/// See https://svelte.dev/docs/svelte/basic-markup#Element-attributes.
 pub struct SvelteAttribute<'s> {
     pub name: Option<&'s str>,
     pub expr: (&'s str, usize),
 }
 
+/// A Svelte await block `{#await expression}...{:then name}...{:catch name}...{/await}`.
+///
+/// See https://svelte.dev/docs/svelte/await.
 pub struct SvelteAwaitBlock<'s> {
     pub expr: (&'s str, usize),
     pub then_binding: Option<(&'s str, usize)>,
@@ -190,11 +245,21 @@ pub struct SvelteAwaitBlock<'s> {
     pub catch_block: Option<SvelteCatchBlock<'s>>,
 }
 
+/// The `{:catch error}...` part of a `SvelteAwaitBlock`.
 pub struct SvelteCatchBlock<'s> {
     pub binding: Option<(&'s str, usize)>,
     pub children: Vec<Node<'s>>,
 }
 
+/// The `{:then value}...` part of a `SvelteAwaitBlock`.
+pub struct SvelteThenBlock<'s> {
+    pub binding: (&'s str, usize),
+    pub children: Vec<Node<'s>>,
+}
+
+/// A Svelte each block: `{#each expression as name}...{/each}`.
+///
+/// See https://svelte.dev/docs/svelte/each.
 pub struct SvelteEachBlock<'s> {
     pub expr: (&'s str, usize),
     pub binding: (&'s str, usize),
@@ -204,11 +269,9 @@ pub struct SvelteEachBlock<'s> {
     pub else_children: Option<Vec<Node<'s>>>,
 }
 
-pub struct SvelteElseIfBlock<'s> {
-    pub expr: (&'s str, usize),
-    pub children: Vec<Node<'s>>,
-}
-
+/// A Svelte if block: `{#if expression}...{:else if expression}...{/if}`.
+///
+/// See https://svelte.dev/docs/svelte/if.
 pub struct SvelteIfBlock<'s> {
     pub expr: (&'s str, usize),
     pub children: Vec<Node<'s>>,
@@ -216,49 +279,75 @@ pub struct SvelteIfBlock<'s> {
     pub else_children: Option<Vec<Node<'s>>>,
 }
 
+/// The `{:else if condition}...` part of a `SvelteIfBlock`.
+pub struct SvelteElseIfBlock<'s> {
+    pub expr: (&'s str, usize),
+    pub children: Vec<Node<'s>>,
+}
+
+/// A Svelte interpolation: `{expression}`.
+///
+/// See https://svelte.dev/docs/svelte/basic-markup#Text-expressions.
 pub struct SvelteInterpolation<'s> {
     pub expr: (&'s str, usize),
 }
 
+/// A Svelte key block: `{#key expression}...{/key}`.
+///
+/// See https://svelte.dev/docs/svelte/key.
 pub struct SvelteKeyBlock<'s> {
     pub expr: (&'s str, usize),
     pub children: Vec<Node<'s>>,
 }
 
-pub struct SvelteThenBlock<'s> {
-    pub binding: (&'s str, usize),
-    pub children: Vec<Node<'s>>,
-}
-
+/// A Svelte snippet block: `{#snippet name()}...{/snippet}`.
+///
+/// See https://svelte.dev/docs/svelte/snippet.
 pub struct SvelteSnippetBlock<'s> {
     pub signature: (&'s str, usize),
     pub children: Vec<Node<'s>>,
 }
 
+/// A plain text node.
 pub struct TextNode<'s> {
     pub raw: &'s str,
     pub line_breaks: usize,
     pub start: usize,
 }
 
+/// A Vento block: `{{ keyword ... }}...{{ /keyword }}`
+///
+/// See https://vento.js.org/syntax/blocks.
 pub struct VentoBlock<'s> {
     pub body: Vec<VentoTagOrChildren<'s>>,
 }
 
+/// A Vento comment: `{{# ... #}}`.
+///
+/// See https://vento.js.org/syntax/comments/.
 pub struct VentoComment<'s> {
     pub raw: &'s str,
 }
 
+/// A Vento eval block for JavaScript evaluation: `{{> ... }}`.
+///
+/// See https://vento.js.org/syntax/javascript/.
 pub struct VentoEval<'s> {
     pub raw: &'s str,
     pub start: usize,
 }
 
+/// A Vento interpolation `{{ ... }}`.
+///
+/// See https://vento.js.org/syntax/print/.
 pub struct VentoInterpolation<'s> {
     pub expr: &'s str,
     pub start: usize,
 }
 
+/// A Vento tag: `{{ keyword ... }}`.
+///
+/// See https://vento.js.org/syntax/include/.
 pub struct VentoTag<'s> {
     pub tag: &'s str,
     pub trim_prev: bool,
@@ -270,12 +359,18 @@ pub enum VentoTagOrChildren<'s> {
     Children(Vec<Node<'s>>),
 }
 
+/// A Vue directive: `v-if`, `v-for`, etc.
+///
+/// See https://vuejs.org/guide/essentials/template-syntax.html#directives.
 pub struct VueDirective<'s> {
     pub name: &'s str,
     pub arg_and_modifiers: Option<&'s str>,
     pub value: Option<(&'s str, usize)>,
 }
 
+/// A Vue interpolation: `{{ expression }}`.
+///
+/// See https://vuejs.org/guide/essentials/template-syntax.html#text-interpolation.
 pub struct VueInterpolation<'s> {
     pub expr: &'s str,
     pub start: usize,

--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -1,4 +1,4 @@
-/// An Angular for loop: `@for ( ... )`.
+/// Angular for loop: `@for ( ... )`.
 ///
 /// See https://angular.dev/api/core/@for.
 pub struct AngularFor<'s> {
@@ -10,7 +10,7 @@ pub struct AngularFor<'s> {
     pub empty: Option<Vec<Node<'s>>>,
 }
 
-/// An Angular conditional block: `@if ( condition )`.
+/// Angular conditional block: `@if ( condition )`.
 ///
 /// See https://angular.dev/api/core/@if.
 pub struct AngularIf<'s> {
@@ -21,7 +21,7 @@ pub struct AngularIf<'s> {
     pub else_children: Option<Vec<Node<'s>>>,
 }
 
-/// An Angular else-if block: `@else if ( condition )`.
+/// Angular else-if block: `@else if ( condition )`.
 ///
 /// See https://angular.dev/api/core/@if.
 pub struct AngularElseIf<'s> {
@@ -30,7 +30,7 @@ pub struct AngularElseIf<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// An Angular interpolation: `{{ expression }}`.
+/// Angular interpolation: `{{ expression }}`.
 ///
 /// See https://angular.dev/guide/templates/binding#render-dynamic-text-with-text-interpolation.
 pub struct AngularInterpolation<'s> {
@@ -38,7 +38,7 @@ pub struct AngularInterpolation<'s> {
     pub start: usize,
 }
 
-/// An Angular let variable declaration: `@let name = expression`.
+/// Angular let variable declaration: `@let name = expression`.
 ///
 /// See https://angular.dev/api/core/@let.
 pub struct AngularLet<'s> {
@@ -46,7 +46,7 @@ pub struct AngularLet<'s> {
     pub expr: (&'s str, usize),
 }
 
-/// An Angular switch statement: `@switch (expression)`.
+/// Angular switch statement: `@switch (expression)`.
 ///
 /// See https://angular.dev/api/core/@switch.
 pub struct AngularSwitch<'s> {
@@ -63,7 +63,7 @@ pub struct AngularSwitchArm<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// An Astro attribute: `{expression}` or `name={expression}`.
+/// Astro attribute: `{expression}` or `name={expression}`.
 ///
 /// See https://docs.astro.build/en/reference/astro-syntax/#dynamic-attributes.
 pub struct AstroAttribute<'s> {
@@ -71,7 +71,7 @@ pub struct AstroAttribute<'s> {
     pub expr: (&'s str, usize),
 }
 
-/// An Astro expression block: `{...}`.
+/// Astro expression block: `{...}`.
 ///
 /// See https://docs.astro.build/en/reference/astro-syntax/#dynamic-html.
 pub struct AstroExpr<'s> {
@@ -97,14 +97,14 @@ pub enum Attribute<'s> {
     VueDirective(VueDirective<'s>),
 }
 
-/// A comment in HTML: `<!-- ... -->`.
+/// Comment in HTML: `<!-- ... -->`.
 ///
 /// See https://developer.mozilla.org/en-US/docs/Web/HTML/Comments
 pub struct Comment<'s> {
     pub raw: &'s str,
 }
 
-/// An HTML doctype declaration: `<!DOCTYPE ...>`.
+/// HTML doctype declaration: `<!DOCTYPE ...>`.
 ///
 /// See https://developer.mozilla.org/en-US/docs/Glossary/Doctype
 pub struct Doctype<'s> {
@@ -112,7 +112,7 @@ pub struct Doctype<'s> {
     pub value: &'s str,
 }
 
-/// An HTML element with its attributes and children.
+/// HTML element with its attributes and children.
 ///
 /// See https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 pub struct Element<'s> {
@@ -132,28 +132,28 @@ pub struct FrontMatter<'s> {
     pub start: usize,
 }
 
-/// A Jinja block containing nested Jinja tags or HTML elements.
+/// Jinja block containing nested Jinja tags or HTML elements.
 ///
 /// See https://jinja.palletsprojects.com/en/stable/templates/#list-of-control-structures.
 pub struct JinjaBlock<'s, T> {
     pub body: Vec<JinjaTagOrChildren<'s, T>>,
 }
 
-/// A Jinja comment: `{# ... #}`.
+/// Jinja comment: `{# ... #}`.
 ///
 /// See https://jinja.palletsprojects.com/en/stable/templates/#comments.
 pub struct JinjaComment<'s> {
     pub raw: &'s str,
 }
 
-/// A Jinja interpolation: `{{ ... }}`.
+/// Jinja interpolation: `{{ ... }}`.
 ///
 /// See https://jinja.palletsprojects.com/en/stable/templates/#expressions.
 pub struct JinjaInterpolation<'s> {
     pub expr: &'s str,
 }
 
-/// A Jinja tag: `{% ... %}`.
+/// Jinja tag: `{% ... %}`.
 ///
 /// See https://jinja.palletsprojects.com/en/stable/templates/#list-of-control-structures.
 pub struct JinjaTag<'s> {
@@ -165,7 +165,7 @@ pub enum JinjaTagOrChildren<'s, T> {
     Children(Vec<T>),
 }
 
-/// A standard HTML attribute.
+/// Standard HTML attribute.
 ///
 /// See https://developer.mozilla.org/en-US/docs/Glossary/Attribute
 pub struct NativeAttribute<'s> {
@@ -214,7 +214,7 @@ pub struct Root<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// A Svelte `@` tag: (`@render`, `@const`, etc).
+/// Svelte `@` tag: (`@render`, `@const`, etc).
 ///
 /// See https://svelte.dev/docs/svelte/@render.
 pub struct SvelteAtTag<'s> {
@@ -222,7 +222,7 @@ pub struct SvelteAtTag<'s> {
     pub expr: (&'s str, usize),
 }
 
-/// A Svelte attribute: `{expression}` or `name={expression}`.
+/// Svelte attribute: `{expression}` or `name={expression}`.
 ///
 /// See https://svelte.dev/docs/svelte/basic-markup#Element-attributes.
 pub struct SvelteAttribute<'s> {
@@ -230,7 +230,7 @@ pub struct SvelteAttribute<'s> {
     pub expr: (&'s str, usize),
 }
 
-/// A Svelte await block `{#await expression}...{:then name}...{:catch name}...{/await}`.
+/// Svelte await block `{#await expression}...{:then name}...{:catch name}...{/await}`.
 ///
 /// See https://svelte.dev/docs/svelte/await.
 pub struct SvelteAwaitBlock<'s> {
@@ -254,7 +254,7 @@ pub struct SvelteThenBlock<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// A Svelte each block: `{#each expression as name}...{/each}`.
+/// Svelte each block: `{#each expression as name}...{/each}`.
 ///
 /// See https://svelte.dev/docs/svelte/each.
 pub struct SvelteEachBlock<'s> {
@@ -266,7 +266,7 @@ pub struct SvelteEachBlock<'s> {
     pub else_children: Option<Vec<Node<'s>>>,
 }
 
-/// A Svelte if block: `{#if expression}...{:else if expression}...{/if}`.
+/// Svelte if block: `{#if expression}...{:else if expression}...{/if}`.
 ///
 /// See https://svelte.dev/docs/svelte/if.
 pub struct SvelteIfBlock<'s> {
@@ -282,14 +282,14 @@ pub struct SvelteElseIfBlock<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// A Svelte interpolation: `{expression}`.
+/// Svelte interpolation: `{expression}`.
 ///
 /// See https://svelte.dev/docs/svelte/basic-markup#Text-expressions.
 pub struct SvelteInterpolation<'s> {
     pub expr: (&'s str, usize),
 }
 
-/// A Svelte key block: `{#key expression}...{/key}`.
+/// Svelte key block: `{#key expression}...{/key}`.
 ///
 /// See https://svelte.dev/docs/svelte/key.
 pub struct SvelteKeyBlock<'s> {
@@ -297,7 +297,7 @@ pub struct SvelteKeyBlock<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// A Svelte snippet block: `{#snippet name()}...{/snippet}`.
+/// Svelte snippet block: `{#snippet name()}...{/snippet}`.
 ///
 /// See https://svelte.dev/docs/svelte/snippet.
 pub struct SvelteSnippetBlock<'s> {
@@ -305,28 +305,28 @@ pub struct SvelteSnippetBlock<'s> {
     pub children: Vec<Node<'s>>,
 }
 
-/// A plain text node.
+/// Plain text node.
 pub struct TextNode<'s> {
     pub raw: &'s str,
     pub line_breaks: usize,
     pub start: usize,
 }
 
-/// A Vento block: `{{ keyword ... }}...{{ /keyword }}`
+/// Vento block: `{{ keyword ... }}...{{ /keyword }}`
 ///
 /// See https://vento.js.org/syntax/blocks.
 pub struct VentoBlock<'s> {
     pub body: Vec<VentoTagOrChildren<'s>>,
 }
 
-/// A Vento comment: `{{# ... #}}`.
+/// Vento comment: `{{# ... #}}`.
 ///
 /// See https://vento.js.org/syntax/comments/.
 pub struct VentoComment<'s> {
     pub raw: &'s str,
 }
 
-/// A Vento eval block for JavaScript evaluation: `{{> ... }}`.
+/// Vento eval block for JavaScript evaluation: `{{> ... }}`.
 ///
 /// See https://vento.js.org/syntax/javascript/.
 pub struct VentoEval<'s> {
@@ -334,7 +334,7 @@ pub struct VentoEval<'s> {
     pub start: usize,
 }
 
-/// A Vento interpolation `{{ ... }}`.
+/// Vento interpolation `{{ ... }}`.
 ///
 /// See https://vento.js.org/syntax/print/.
 pub struct VentoInterpolation<'s> {
@@ -342,7 +342,7 @@ pub struct VentoInterpolation<'s> {
     pub start: usize,
 }
 
-/// A Vento tag: `{{ keyword ... }}`.
+/// Vento tag: `{{ keyword ... }}`.
 ///
 /// See https://vento.js.org/syntax/include/.
 pub struct VentoTag<'s> {
@@ -356,7 +356,7 @@ pub enum VentoTagOrChildren<'s> {
     Children(Vec<Node<'s>>),
 }
 
-/// A Vue directive: `v-if`, `v-for`, etc.
+/// Vue directive: `v-if`, `v-for`, etc.
 ///
 /// See https://vuejs.org/guide/essentials/template-syntax.html#directives.
 pub struct VueDirective<'s> {
@@ -365,7 +365,7 @@ pub struct VueDirective<'s> {
     pub value: Option<(&'s str, usize)>,
 }
 
-/// A Vue interpolation: `{{ expression }}`.
+/// Vue interpolation: `{{ expression }}`.
 ///
 /// See https://vuejs.org/guide/essentials/template-syntax.html#text-interpolation.
 pub struct VueInterpolation<'s> {


### PR DESCRIPTION
Following https://github.com/g-plane/markup_fmt/pull/111#issuecomment-2781736960

This adds links to relevant documentation pages about the node along with a short description and example syntax.

Let me know if you want me to adjust anything.