### PR TITLE
Try to converge in one pass when formatting a style attr with malva

### DIFF
--- a/dprint_plugin/tests/integration/biome/style-attr.html.snap
+++ b/dprint_plugin/tests/integration/biome/style-attr.html.snap
@@ -5,3 +5,11 @@ source: dprint_plugin/tests/integration.rs
 
 <ul style="display: grid; grid-template-columns: 50% 50%; justify-items: stretch; padding: 0">
 </ul>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+  aaaa
+</p>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+  aaaa
+</p>

--- a/dprint_plugin/tests/integration/dprint_ts/style-attr.html.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/style-attr.html.snap
@@ -5,3 +5,11 @@ source: dprint_plugin/tests/integration.rs
 
 <ul style="display: grid; grid-template-columns: 50% 50%; justify-items: stretch; padding: 0">
 </ul>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+  aaaa
+</p>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+  aaaa
+</p>

--- a/dprint_plugin/tests/integration/style-attr.html
+++ b/dprint_plugin/tests/integration/style-attr.html
@@ -2,3 +2,18 @@
 
 <ul style="display: grid; grid-template-columns: 50% 50%; justify-items: stretch; padding: 0">
 </ul>
+
+<p
+  style="
+    margin: 0;
+    font-size: 14px;
+    display: flex;
+    flex-direction: column-reverse;
+  "
+>
+    aaaa
+</p>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+    aaaa
+</p>

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1972,6 +1972,8 @@ fn is_all_ascii_whitespace(s: &str) -> bool {
 
 fn is_multi_line_attr(attr: &Attribute) -> bool {
     match attr {
+        // External formatter (Malva) always format style attr on a single line (see `singleLineTopLevelDeclarations`)
+        Attribute::Native(attr) if attr.name.eq_ignore_ascii_case("style") => false,
         Attribute::Native(attr) => attr
             .value
             .map(|(value, _)| value.trim().contains('\n'))

--- a/markup_fmt/tests/fmt/html/attributes/style.html
+++ b/markup_fmt/tests/fmt/html/attributes/style.html
@@ -52,3 +52,18 @@ style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-pro
 
 <div style="color: red; {{ otherStyles }}"
 ></div>
+
+<p
+  style="
+    margin: 0;
+    font-size: 14px;
+    display: flex;
+    flex-direction: column-reverse;
+  "
+>
+  aaaa
+</p>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+  aaaa
+</p>

--- a/markup_fmt/tests/fmt/html/attributes/style.snap
+++ b/markup_fmt/tests/fmt/html/attributes/style.snap
@@ -7,8 +7,7 @@ source: markup_fmt/tests/fmt.rs
 <div style=""></div>
 <div style></div>
 
-<div
-  style="all: initial;display: block;
+<div style="all: initial;display: block;
 contain: content;text-align: center;
 
 
@@ -16,8 +15,7 @@ contain: content;text-align: center;
 background: linear-gradient(to left, hotpink, #FFF00F, #ccc, hsla(240, 100%, 50%, .05), transparent);
 background: linear-gradient(to left, hsla(240, 100%, 50%, .05), red);
 max-width: 500px;margin: 0 auto;
-border-radius: 8px;transition: transform .2s ease-out;"
->
+border-radius: 8px;transition: transform .2s ease-out;">
 </div>
 
 <div style="background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transparent);">
@@ -52,3 +50,14 @@ display: inline"></div>
 <div style="{{ ...styles }}"></div>
 
 <div style="color: red; {{ otherStyles }}"></div>
+
+<p style="margin: 0;
+    font-size: 14px;
+    display: flex;
+    flex-direction: column-reverse;">
+  aaaa
+</p>
+
+<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
+  aaaa
+</p>


### PR DESCRIPTION
Currently the following snippet need two pass to format:

```html
<p
  style="
    margin: 0;
    font-size: 14px;
    display: flex;
    flex-direction: column-reverse;
  "
>
    aaaa
</p>

# First pass
<p 
  style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse"
>
  aaaa
</p>

# Second pass
<p style="margin: 0; font-size: 14px; display: flex; flex-direction: column-reverse">
  aaaa
</p>
```

This happens because we choose to add a newline or not based on the initial attr content. At first it contains a newline but the formatting removes it, hence the second pass.

The current fix is not perfect because it will slightly change the formatting if you don't use an external formatter.
Do you have an idea on how to know if the formatted text will end on multiple lines or not from `is_multi_line_attr` ?