### PR TITLE
 Support unquoted attr value recovery for jinja tags & blocks

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -833,16 +833,14 @@ impl<'s> Parser<'s> {
                         chars.next();
                         match chars.peek() {
                             Some((_, '%')) => {
-                                if let Ok(_) =
-                                    self.parse_jinja_tag_or_block(None, &mut Parser::parse_node)
+                                if self
+                                    .parse_jinja_tag_or_block(None, &mut Parser::parse_node)
+                                    .is_ok()
                                 {
-                                    end = if let Some((i, _)) = self.chars.peek() {
-                                        *i - 1
-                                    } else {
-                                        return Err(
+                                    end =
+                                        self.chars.peek().map(|(i, _)| i - 1).ok_or_else(|| {
                                             self.emit_error(SyntaxErrorKind::ExpectAttrValue)
-                                        );
-                                    };
+                                        })?;
                                 } else {
                                     self.chars.next();
                                 }
@@ -851,8 +849,8 @@ impl<'s> Parser<'s> {
                                 chars.next();
                                 // We use inclusive range when returning string,
                                 // so we need to substract 1 here.
-                                end +=
-                                    self.parse_mustache_interpolation()?.0.len() + "{{}}".len() - 1;
+                                let (interpolation, _) = self.parse_mustache_interpolation()?;
+                                end += interpolation.len() + "{{}}".len() - 1;
                             }
                             _ => {
                                 self.chars.next();

--- a/markup_fmt/tests/fmt/jinja/attributes/unquoted-assignment.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/unquoted-assignment.jinja
@@ -1,0 +1,12 @@
+<a id={% include 'url.html' %}>{% include 'url.html' %}</a>
+<a id={% include 'url.html' %}AA>{% include 'url.html' %}</a>
+<a id=BB{% include 'url.html' %}AA>{% include 'url.html' %}</a>
+
+<a id=super-{% include 'url.html' %}-long-{{ id2 }} class="fff">{% include 'url.html' %}</a>
+<a id={%    include 'url.html'    %} class="fff">{% include 'url.html' %}</a>
+
+<html alt={% url ... %}></html>
+
+<a id={% include "url.html" %}>{% include 'url.html' %}</a>
+
+<input value={% if initial_value %}{{ initial_value }}{% else %}''{% endif %}>

--- a/markup_fmt/tests/fmt/jinja/attributes/unquoted-assignment.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/unquoted-assignment.snap
@@ -1,0 +1,17 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<a id="{% include 'url.html' %}">{% include 'url.html' %}</a>
+<a id="{% include 'url.html' %}AA">{% include 'url.html' %}</a>
+<a id="BB{% include 'url.html' %}AA">{% include 'url.html' %}</a>
+
+<a id="super-{% include 'url.html' %}-long-{{ id2 }}" class="fff">{%
+    include 'url.html'
+  %}</a>
+<a id="{%    include 'url.html'    %}" class="fff">{% include 'url.html' %}</a>
+
+<html alt="{% url ... %}"></html>
+
+<a id="{% include "url.html" %}">{% include 'url.html' %}</a>
+
+<input value="{% if initial_value %}{{ initial_value }}{% else %}''{% endif %}">


### PR DESCRIPTION
This expand https://github.com/g-plane/markup_fmt/pull/23 to support recovery from unquoted jinja tag/block as well as interpolations in attribute values.


```diff
-<html alt={% url ... %}></html>
+<html alt="{% url ... %}"></html>
-<input value={% if initial_value %}{{ initial_value }}{% endif %}>
+<input value="{% if initial_value %}{{ initial_value }}{% endif %}">
```

Turns out i had a bunch of these in various projects and the fix was not too involved so here we are.

Prior to that, `markup_fmt` would crash on these with `ExpectAttrName` errors like the following:
- `Syntax(SyntaxError { kind: ExpectAttrName, pos: 17, line: 1, column: 18 })"`