### PR TITLE
feat: allow to format Jinja expr and stmt with external formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Or Biome:
 
 If you use Biome, you need to set [`"scriptFormatter"`](https://markup-fmt.netlify.app/config/script-formatter.html) to `"biome"` in markup_fmt's config.
 
+If you want to format Jinja, it's recommended to add [Pretty Jinja](https://github.com/g-plane/pretty_jinja) dprint plugin as well.
+
 After adding the dprint plugins, update your `dprint.json` and add configuration:
 
 ```jsonc

--- a/markup_fmt/src/ast.rs
+++ b/markup_fmt/src/ast.rs
@@ -178,6 +178,7 @@ pub struct JinjaComment<'s> {
 /// See https://jinja.palletsprojects.com/en/stable/templates/#expressions.
 pub struct JinjaInterpolation<'s> {
     pub expr: &'s str,
+    pub start: usize,
 }
 
 #[derive(Debug)]
@@ -186,6 +187,7 @@ pub struct JinjaInterpolation<'s> {
 /// See https://jinja.palletsprojects.com/en/stable/templates/#list-of-control-structures.
 pub struct JinjaTag<'s> {
     pub content: &'s str,
+    pub start: usize,
 }
 
 #[derive(Debug)]

--- a/markup_fmt/src/ctx.rs
+++ b/markup_fmt/src/ctx.rs
@@ -428,6 +428,30 @@ where
         )
     }
 
+    pub(crate) fn format_jinja<'a>(
+        &mut self,
+        code: &'a str,
+        start: usize,
+        ext: &'static str,
+        state: &State,
+    ) -> Cow<'a, str> {
+        self.format_with_external_formatter(
+            self.source
+                .get(0..start)
+                .unwrap_or_default()
+                .replace(|c: char| !c.is_ascii_whitespace(), " ")
+                + code,
+            Hints {
+                print_width: self
+                    .print_width
+                    .saturating_sub((state.indent_level as usize) * self.indent_width),
+                indent_level: state.indent_level,
+                attr: false,
+                ext,
+            },
+        )
+    }
+
     fn format_with_external_formatter<'a>(
         &mut self,
         code: String,

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -1366,6 +1366,7 @@ impl<'s> Parser<'s> {
 
         Ok(JinjaTag {
             content: unsafe { self.source.get_unchecked(start..end) },
+            start,
         })
     }
 
@@ -1596,7 +1597,7 @@ impl<'s> Parser<'s> {
                                     NodeKind::VueInterpolation(VueInterpolation { expr, start })
                                 }
                                 Language::Jinja => {
-                                    NodeKind::JinjaInterpolation(JinjaInterpolation { expr })
+                                    NodeKind::JinjaInterpolation(JinjaInterpolation { expr, start })
                                 }
                                 Language::Angular => {
                                     NodeKind::AngularInterpolation(AngularInterpolation {

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -878,13 +878,16 @@ impl<'s> DocGen<'s> for JinjaComment<'s> {
 }
 
 impl<'s> DocGen<'s> for JinjaInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
     where
         F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
     {
         Doc::text("{{")
             .append(Doc::line_or_space())
-            .append(Doc::text(self.expr.trim()))
+            .concat(reflow_with_indent(
+                ctx.format_jinja(self.expr, self.start, "markup-fmt-jinja-expr", state)
+                    .trim(),
+            ))
             .nest(ctx.indent_width)
             .append(Doc::line_or_space())
             .append(Doc::text("}}"))
@@ -893,7 +896,7 @@ impl<'s> DocGen<'s> for JinjaInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for JinjaTag<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
     where
         F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
     {
@@ -912,21 +915,21 @@ impl<'s> DocGen<'s> for JinjaTag<'s> {
             (content, "")
         };
 
-        let docs = Doc::text("{%")
-            .append(Doc::text(prefix))
-            .append(Doc::line_or_space());
-        let docs = if content.trim().starts_with("set") {
-            if let Some((left, right)) = content.split_once('=') {
-                docs.append(Doc::text(left.trim()))
-                    .append(Doc::text(" = "))
-                    .append(Doc::text(right.trim()))
-            } else {
-                docs.append(Doc::text(content.trim()))
-            }
-        } else {
-            docs.append(Doc::text(content.trim()))
-        };
-        docs.nest(ctx.indent_width)
+        let mut docs = Vec::with_capacity(5);
+        docs.push(Doc::text("{%"));
+        docs.push(Doc::text(prefix));
+        docs.push(Doc::line_or_space());
+        docs.extend(reflow_with_indent(
+            ctx.format_jinja(
+                content,
+                self.start + prefix.len(),
+                "markup-fmt-jinja-stmt",
+                state,
+            )
+            .trim(),
+        ));
+        Doc::list(docs)
+            .nest(ctx.indent_width)
             .append(Doc::line_or_space())
             .append(Doc::text(suffix))
             .append(Doc::text("%}"))

--- a/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
+++ b/markup_fmt/tests/fmt/jinja/single-tag/fixture.snap
@@ -16,4 +16,4 @@ source: markup_fmt/tests/fmt.rs
 {% set ns = namespace(found=false) %}
 {% set ns.foo = 'bar' %}
 {% set pipe = joiner("|") %}
-{% set pipe = joiner("|") %}
+{% set pipe=joiner("|") %}


### PR DESCRIPTION
This allows Jinja expressions (code inside `{{ }}`) and statements (code inside `{% %}`) being formatted by external formatter, such as [Pretty Jinja](https://github.com/g-plane/pretty_jinja).

cc @UnknownPlatypus 