### PR TITLE
fix(vue-component-case): ignore svg tags

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -416,11 +416,17 @@ impl<'s> DocGen<'s> for Element<'s> {
             {
                 Cow::from(self.tag_name.to_ascii_lowercase())
             }
-            Language::Vue if !css_dataset::tags::SVG_TAGS.iter().any(|tag| tag.eq_ignore_ascii_case(self.tag_name)) => match ctx.options.vue_component_case {
-                VueComponentCase::Ignore => Cow::from(self.tag_name),
-                VueComponentCase::PascalCase => helpers::kebab2pascal(self.tag_name),
-                VueComponentCase::KebabCase => helpers::pascal2kebab(self.tag_name),
-            },
+            Language::Vue
+                if !css_dataset::tags::SVG_TAGS
+                    .iter()
+                    .any(|tag| tag.eq_ignore_ascii_case(self.tag_name)) =>
+            {
+                match ctx.options.vue_component_case {
+                    VueComponentCase::Ignore => Cow::from(self.tag_name),
+                    VueComponentCase::PascalCase => helpers::kebab2pascal(self.tag_name),
+                    VueComponentCase::KebabCase => helpers::pascal2kebab(self.tag_name),
+                }
+            }
             _ => Cow::from(self.tag_name),
         };
         let is_root = state.is_root;

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -416,7 +416,7 @@ impl<'s> DocGen<'s> for Element<'s> {
             {
                 Cow::from(self.tag_name.to_ascii_lowercase())
             }
-            Language::Vue => match ctx.options.vue_component_case {
+            Language::Vue if !css_dataset::tags::SVG_TAGS.iter().any(|tag| tag.eq_ignore_ascii_case(self.tag_name)) => match ctx.options.vue_component_case {
                 VueComponentCase::Ignore => Cow::from(self.tag_name),
                 VueComponentCase::PascalCase => helpers::kebab2pascal(self.tag_name),
                 VueComponentCase::KebabCase => helpers::pascal2kebab(self.tag_name),

--- a/markup_fmt/tests/fmt/vue/component-case/case.default.snap
+++ b/markup_fmt/tests/fmt/vue/component-case/case.default.snap
@@ -8,4 +8,13 @@ source: markup_fmt/tests/fmt.rs
   <my-component></my-component>
   <My-Component></My-Component>
   <myComponent></myComponent>
+  <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1" />
+        <stop offset="100%" style="stop-color:rgb(0,0,255);stop-opacity:1" />
+      </linearGradient>
+    </defs>
+    <rect width="200" height="200" fill="url(#grad1)" />
+  </svg>
 </template>

--- a/markup_fmt/tests/fmt/vue/component-case/case.kebab.snap
+++ b/markup_fmt/tests/fmt/vue/component-case/case.kebab.snap
@@ -8,4 +8,13 @@ source: markup_fmt/tests/fmt.rs
   <my-component></my-component>
   <my-component></my-component>
   <my-component></my-component>
+  <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1" />
+        <stop offset="100%" style="stop-color:rgb(0,0,255);stop-opacity:1" />
+      </linearGradient>
+    </defs>
+    <rect width="200" height="200" fill="url(#grad1)" />
+  </svg>
 </template>

--- a/markup_fmt/tests/fmt/vue/component-case/case.pascal.snap
+++ b/markup_fmt/tests/fmt/vue/component-case/case.pascal.snap
@@ -8,4 +8,13 @@ source: markup_fmt/tests/fmt.rs
   <MyComponent></MyComponent>
   <MyComponent></MyComponent>
   <MyComponent></MyComponent>
+  <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1" />
+        <stop offset="100%" style="stop-color:rgb(0,0,255);stop-opacity:1" />
+      </linearGradient>
+    </defs>
+    <rect width="200" height="200" fill="url(#grad1)" />
+  </svg>
 </template>

--- a/markup_fmt/tests/fmt/vue/component-case/case.vue
+++ b/markup_fmt/tests/fmt/vue/component-case/case.vue
@@ -5,4 +5,13 @@
   <my-component></my-component>
   <My-Component></My-Component>
   <myComponent></myComponent>
+  <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" style="stop-color:rgb(255,255,0);stop-opacity:1" />
+        <stop offset="100%" style="stop-color:rgb(0,0,255);stop-opacity:1" />
+      </linearGradient>
+    </defs>
+    <rect width="200" height="200" fill="url(#grad1)" />
+  </svg>
 </template>


### PR DESCRIPTION
This pull request fixes https://github.com/g-plane/markup_fmt/issues/138 by using `css_dataset` to ignore the SVG tags that should not have their case formatted by `vueComponentCase`. Let me know if I introduced some bad practice, I am not familiar with Rust.