### PR TITLE
Add `try_consume_str` and use it

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -979,7 +979,6 @@ impl<'s> Parser<'s> {
         } else {
             return Err(self.emit_error(SyntaxErrorKind::ExpectDoctype));
         };
-
         let keyword = if let Some((end, _)) = self.try_consume_str_ignore_case("doctype") {
             unsafe { self.source.get_unchecked(keyword_start..end + 1) }
         } else {
@@ -1835,7 +1834,11 @@ impl<'s> Parser<'s> {
     }
 
     fn parse_svelte_await_block(&mut self) -> PResult<Box<SvelteAwaitBlock<'s>>> {
-        if self.try_consume_str("{#await ").is_none() {
+        if self
+            .try_consume_str("{#await")
+            .and_then(|_| self.chars.next_if(|(_, c)| c.is_ascii_whitespace()))
+            .is_none()
+        {
             return Err(self.emit_error(SyntaxErrorKind::ExpectSvelteIfBlock));
         };
         self.skip_ws();
@@ -2050,7 +2053,11 @@ impl<'s> Parser<'s> {
     }
 
     fn parse_svelte_each_block(&mut self) -> PResult<SvelteEachBlock<'s>> {
-        if self.try_consume_str("{#each ").is_none() {
+        if self
+            .try_consume_str("{#each")
+            .and_then(|_| self.chars.next_if(|(_, c)| c.is_ascii_whitespace()))
+            .is_none()
+        {
             return Err(self.emit_error(SyntaxErrorKind::ExpectSvelteIfBlock));
         };
         self.skip_ws();


### PR DESCRIPTION
Another small refacto to simplify these patterns:

```diff
-.and_then(|_| self.chars.next_if(|(_, c)| *c == '@'))
-.and_then(|_| self.chars.next_if(|(_, c)| *c == 'a'))
-.and_then(|_| self.chars.next_if(|(_, c)| *c == 't'))
-.and_then(|_| self.chars.next_if(|(_, c)| *c == 't'))
-.and_then(|_| self.chars.next_if(|(_, c)| *c == 'a'))
-.and_then(|_| self.chars.next_if(|(_, c)| *c == 'c'))
-.and_then(|_| self.chars.next_if(|(_, c)| *c == 'h'))
+.and_then(|_| self.try_consume_str("@attach"))
```

It also changes the behavior because we clone the iterator so in case of failure, the position is at the start instead of being the middle.

I can revert this part if needed, it was a bit inconsistent so I tried to apply the same behavior everywhere. 
The difference is that on failure, the position is at the start of the node we failed to parse instead of where we failed to parse