### PR TITLE
Always swap wrapping quotes if attribute value contain one

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2679,7 +2679,6 @@ fn compute_attr_value_quote<'s, E, F>(
 where
     F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
 {
-    let is_jinja = matches!(ctx.language, Language::Jinja);
     let has_single = attr_value.contains('\'');
     let has_double = attr_value.contains('"');
     if has_double && has_single {
@@ -2690,9 +2689,9 @@ where
         } else {
             Doc::text("'")
         }
-    } else if has_double && !is_jinja {
+    } else if has_double {
         Doc::text("'")
-    } else if has_single && !is_jinja {
+    } else if has_single {
         Doc::text("\"")
     } else if let Quotes::Double = ctx.options.quotes {
         Doc::text("\"")

--- a/markup_fmt/tests/fmt/jinja/attributes/mixed-quotes/mixed-quotes.double.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/mixed-quotes/mixed-quotes.double.snap
@@ -4,7 +4,7 @@ source: markup_fmt/tests/fmt.rs
 <div data-content="{% if status == "active" %}I'd like it{% endif %}"></div>
 <div data-content='{% if status == 'active' %}I"d like it{% endif %}'></div>
 
-<div data-content="{% if status == "active" %}Id like it{% endif %}"></div>
+<div data-content='{% if status == "active" %}Id like it{% endif %}'></div>
 <div data-content="{% if status == 'active' %}Id like it{% endif %}"></div>
 
 <!-- Unchanged (attr value contains both single and double quotes) -->
@@ -15,12 +15,12 @@ source: markup_fmt/tests/fmt.rs
 
 <!-- Should keep "" if quotes = "double" -->
 
-<div data-content="{% if status == "active" %}Yay{% endif %}"></div>
-<input value="{{ initial|default("True") }}" />
-<input value="{{ field.value|default("", true) }}" />
-<button class="{{ ["btn_class", "btn-expand"]|join(" ") }}"></button>
+<div data-content='{% if status == "active" %}Yay{% endif %}'></div>
+<input value='{{ initial|default("True") }}' />
+<input value='{{ field.value|default("", true) }}' />
+<button class='{{ ["btn_class", "btn-expand"]|join(" ") }}'></button>
 {% for row in [1,2] %}
-  <li class="{{ loop.cycle("odd", "even") }}">{{ row }}</li>
+  <li class='{{ loop.cycle("odd", "even") }}'>{{ row }}</li>
 {% endfor %}
 
 <!-- Should keep '' if quotes = "single" -->

--- a/markup_fmt/tests/fmt/jinja/attributes/mixed-quotes/mixed-quotes.single.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/mixed-quotes/mixed-quotes.single.snap
@@ -5,7 +5,7 @@ source: markup_fmt/tests/fmt.rs
 <div data-content='{% if status == 'active' %}I"d like it{% endif %}'></div>
 
 <div data-content='{% if status == "active" %}Id like it{% endif %}'></div>
-<div data-content='{% if status == 'active' %}Id like it{% endif %}'></div>
+<div data-content="{% if status == 'active' %}Id like it{% endif %}"></div>
 
 <!-- Unchanged (attr value contains both single and double quotes) -->
 
@@ -25,10 +25,10 @@ source: markup_fmt/tests/fmt.rs
 
 <!-- Should keep '' if quotes = "single" -->
 
-<div data-content='{% if status == 'active' %}Yay{% endif %}'></div>
-<input value='{{ initial|default('True') }}' />
-<input value='{{ field.value|default('', true) }}' />
-<button class='{{ ['btn_class', 'btn-expand']|join(' ') }}'></button>
+<div data-content="{% if status == 'active' %}Yay{% endif %}"></div>
+<input value="{{ initial|default('True') }}" />
+<input value="{{ field.value|default('', true) }}" />
+<button class="{{ ['btn_class', 'btn-expand']|join(' ') }}"></button>
 {% for row in [1,2] %}
-  <li class='{{ loop.cycle('odd', 'even') }}'>{{ row }}</li>
+  <li class="{{ loop.cycle('odd', 'even') }}">{{ row }}</li>
 {% endfor %}

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
@@ -76,7 +76,7 @@ source: markup_fmt/tests/fmt.rs
   {% else %}
     data-start="08:30:00"
     data-end="20:30:00"
-    data-start_day="{% now "Y-m-d" %}"
+    data-start_day='{% now "Y-m-d" %}'
     data-saturday_start="08:30:00"
     data-saturday_end="20:30:00"
   {% endif %}

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-in-attr-value.snap
@@ -1,11 +1,11 @@
 ---
 source: markup_fmt/tests/fmt.rs
 ---
-<form class="form-control" action="{% url "my_app:subscribe" %}" method="post">
+<form class="form-control" action='{% url "my_app:subscribe" %}' method="post">
   {{ whatever }}
 </form>
 <a
-  href="https://{{ request.get_host }}{% url "newsletter_verify" uuid=subscription.verification_token %}"
+  href='https://{{ request.get_host }}{% url "newsletter_verify" uuid=subscription.verification_token %}'
 >Subscribe to the newsletter!</a>
 <div
   class="first-class {% block extra_classes %}{% endblock %} modal fade"

--- a/markup_fmt/tests/fmt/jinja/attributes/unquoted-assignment.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/unquoted-assignment.snap
@@ -12,6 +12,6 @@ source: markup_fmt/tests/fmt.rs
 
 <html alt="{% url ... %}"></html>
 
-<a id="{% include "url.html" %}">{% include 'url.html' %}</a>
+<a id='{% include "url.html" %}'>{% include 'url.html' %}</a>
 
 <input value="{% if initial_value %}{{ initial_value }}{% else %}''{% endif %}">


### PR DESCRIPTION
Partially revert #102

In retrospect, it was not such a good idea. 
Even tho it works, IDE's and syntax highlighting tools (such as the github code block below or the diff view) are getting lost.

```jinja
<div data-content="{% if status == "active" %}Id like it{% endif %}"></div>
<div data-start_day="{% now "Y-m-d" %}"></div>
```

