### PR TITLE
Improve error messages for `ExpectJinjaBlockEnd`

### DIFF
--- a/markup_fmt/src/error.rs
+++ b/markup_fmt/src/error.rs
@@ -30,7 +30,11 @@ pub enum SyntaxErrorKind {
     ExpectElement,
     ExpectFrontMatter,
     ExpectIdentifier,
-    ExpectJinjaBlockEnd,
+    ExpectJinjaBlockEnd {
+        tag_name: String,
+        line: usize,
+        column: usize,
+    },
     ExpectJinjaTag,
     ExpectKeyword(&'static str),
     ExpectMustacheInterpolation,
@@ -82,7 +86,14 @@ impl fmt::Display for SyntaxErrorKind {
             SyntaxErrorKind::ExpectElement => "expected element".into(),
             SyntaxErrorKind::ExpectFrontMatter => "expected front matter".into(),
             SyntaxErrorKind::ExpectIdentifier => "expected identifier".into(),
-            SyntaxErrorKind::ExpectJinjaBlockEnd => "expected Jinja block end".into(),
+            SyntaxErrorKind::ExpectJinjaBlockEnd {
+                tag_name,
+                line,
+                column,
+            } => format!(
+                "expected end tag for opening Jinja block {{% {tag_name} %}} from line {line}, column {column}"
+            )
+            .into(),
             SyntaxErrorKind::ExpectJinjaTag => "expected Jinja tag".into(),
             SyntaxErrorKind::ExpectKeyword(keyword) => {
                 format!("expected keyword '{keyword}'").into()


### PR DESCRIPTION
Mostly the same as https://github.com/g-plane/markup_fmt/commit/8cadb879f1569ea41303c9e9238ecdd5b202677a but for Jinja block instead of html nodes.

This solves the same issue as in #121: `syntax error 'expected Jinja block end' at line 11, column 0`
```jinja
{% with foo="bar" %}
  <div>

  <!-- 200 lines of html -->

{% endwith %}

  <!-- 200 lines of html -->

</div>
```