### PR TITLE
Improve formatting of Jinja blocks

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -636,29 +636,13 @@ impl<'s> DocGen<'s> for Element<'s> {
         let has_two_more_non_text_children =
             has_two_more_non_text_children(&self.children, ctx.language);
 
-        let (leading_ws, trailing_ws) = if is_empty
-            || ctx.language == Language::Xml
-                && matches!(
-                    &*self.children,
-                    [Node {
-                        kind: NodeKind::Text(..),
-                        ..
-                    }]
-                ) {
-            (Doc::nil(), Doc::nil())
-        } else if is_whitespace_sensitive {
-            (
-                format_ws_sensitive_leading_ws(&self.children),
-                format_ws_sensitive_trailing_ws(&self.children),
-            )
-        } else if has_two_more_non_text_children {
-            (Doc::hard_line(), Doc::hard_line())
-        } else {
-            (
-                format_ws_insensitive_leading_ws(&self.children),
-                format_ws_insensitive_trailing_ws(&self.children),
-            )
-        };
+        let (leading_ws, trailing_ws) = format_leading_trailing_ws(
+            &self.children,
+            is_empty,
+            is_whitespace_sensitive,
+            has_two_more_non_text_children,
+            ctx,
+        );
 
         if tag_name.eq_ignore_ascii_case("script") && ctx.language != Language::Xml {
             if let [
@@ -2660,6 +2644,42 @@ where
     }
 }
 
+fn format_leading_trailing_ws<'s, E, F>(
+    children: &[Node<'s>],
+    is_empty: bool,
+    is_whitespace_sensitive: bool,
+    has_two_more_non_text_children: bool,
+    ctx: &Ctx<'s, E, F>,
+) -> (Doc<'s>, Doc<'s>)
+where
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+{
+    if is_empty
+        || ctx.language == Language::Xml
+            && matches!(
+                children,
+                [Node {
+                    kind: NodeKind::Text(..),
+                    ..
+                }]
+            )
+    {
+        (Doc::nil(), Doc::nil())
+    } else if is_whitespace_sensitive {
+        (
+            format_ws_sensitive_leading_ws(children),
+            format_ws_sensitive_trailing_ws(children),
+        )
+    } else if has_two_more_non_text_children {
+        (Doc::hard_line(), Doc::hard_line())
+    } else {
+        (
+            format_ws_insensitive_leading_ws(children),
+            format_ws_insensitive_trailing_ws(children),
+        )
+    }
+}
+
 fn format_control_structure_block_children<'s, E, F>(
     children: &[Node<'s>],
     ctx: &mut Ctx<'s, E, F>,
@@ -2668,32 +2688,23 @@ fn format_control_structure_block_children<'s, E, F>(
 where
     F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
 {
-    let is_whitespace_sensitive = state.current_tag_name.map_or(true, |current_tag_name| {
-        ctx.is_whitespace_sensitive(current_tag_name)
-    });
-    let is_empty = is_empty_element(&children, is_whitespace_sensitive);
-    let has_multiple_non_text_children = get_has_multiple_non_text_children(&children);
-
-    let (leading_ws, trailing_ws) = if is_empty {
-        (Doc::nil(), Doc::nil())
-    } else if is_whitespace_sensitive {
-        (
-            format_ws_sensitive_leading_ws(&children),
-            format_ws_sensitive_trailing_ws(&children),
-        )
-    } else if has_multiple_non_text_children {
-        (Doc::hard_line(), Doc::hard_line())
-    } else {
-        (
-            format_ws_insensitive_leading_ws(&children),
-            format_ws_insensitive_trailing_ws(&children),
-        )
-    };
+    let is_whitespace_sensitive = state
+        .current_tag_name
+        .is_none_or(|current_tag_name| ctx.is_whitespace_sensitive(current_tag_name));
+    let (leading_ws, trailing_ws) = format_leading_trailing_ws(
+        children,
+        is_empty_element(children, is_whitespace_sensitive),
+        is_whitespace_sensitive,
+        has_two_more_non_text_children(children, ctx.language),
+        ctx,
+    );
     match children {
-        [Node {
-            kind: NodeKind::Text(text_node),
-            ..
-        }] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
+        [
+            Node {
+                kind: NodeKind::Text(text_node),
+                ..
+            },
+        ] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
         _ => leading_ws
             .append(format_children_without_inserting_linebreak(
                 children, ctx, state,

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2668,19 +2668,38 @@ fn format_control_structure_block_children<'s, E, F>(
 where
     F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
 {
+    let is_whitespace_sensitive = state.current_tag_name.map_or(true, |current_tag_name| {
+        ctx.is_whitespace_sensitive(current_tag_name)
+    });
+    let is_empty = is_empty_element(&children, is_whitespace_sensitive);
+    let has_multiple_non_text_children = get_has_multiple_non_text_children(&children);
+
+    let (leading_ws, trailing_ws) = if is_empty {
+        (Doc::nil(), Doc::nil())
+    } else if is_whitespace_sensitive {
+        (
+            format_ws_sensitive_leading_ws(&children),
+            format_ws_sensitive_trailing_ws(&children),
+        )
+    } else if has_multiple_non_text_children {
+        (Doc::hard_line(), Doc::hard_line())
+    } else {
+        (
+            format_ws_insensitive_leading_ws(&children),
+            format_ws_insensitive_trailing_ws(&children),
+        )
+    };
     match children {
-        [
-            Node {
-                kind: NodeKind::Text(text_node),
-                ..
-            },
-        ] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
-        _ => format_ws_sensitive_leading_ws(children)
+        [Node {
+            kind: NodeKind::Text(text_node),
+            ..
+        }] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
+        _ => leading_ws
             .append(format_children_without_inserting_linebreak(
                 children, ctx, state,
             ))
             .nest(ctx.indent_width)
-            .append(format_ws_sensitive_trailing_ws(children)),
+            .append(trailing_ws),
     }
 }
 

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2705,12 +2705,17 @@ where
                 ..
             },
         ] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
-        _ => leading_ws
-            .append(format_children_without_inserting_linebreak(
-                children, ctx, state,
-            ))
-            .nest(ctx.indent_width)
-            .append(trailing_ws),
+        _ => {
+            let children_doc = if is_whitespace_sensitive {
+                format_children_without_inserting_linebreak(children, ctx, state)
+            } else {
+                format_children_with_inserting_linebreak(children, ctx, state)
+            };
+            leading_ws
+                .append(children_doc)
+                .nest(ctx.indent_width)
+                .append(trailing_ws)
+        }
     }
 }
 

--- a/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.jinja
+++ b/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.jinja
@@ -1,0 +1,72 @@
+<div class="contact-info-column">
+    {% if contact.email %}<a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+    {% if contact.email %} <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+    {% if contact.email %} <a href="mailto:{{ contact.email }}"> {{ contact.email }}</a>{% endif %}
+    {% if contact.email %}
+        <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+    {% endif %}
+</div>
+<span class="contact-info-column">
+    {% if contact.email %}<a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+    {% if contact.email %} <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+    {% if contact.email %} <a href="mailto:{{ contact.email }}"> {{ contact.email }}</a>{% endif %}
+    {% if contact.email %}
+        <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+    {% endif %}
+</span>
+
+# p hug the jinja tag here
+{% if page_data.description %}<p class="ds-mb-0 ds-text-current-tint-110 ds-fgdgfdg">AA page_data.description AA</p>{% endif %}
+
+# but it's not required here because we are in a div context
+<div>
+{% if page_data.description %}<p class="ds-mb-0 ds-text-current-tint-110 ds-fgdgfdg">AA page_data.description AA</p>{% endif %}
+</div>
+
+<div>
+{% for drawback in offer_data.offer__drawbacks|underscore_separated_list %}<li>{{ drawback|safe  }}</li>{% endfor %}
+</div>
+
+<select name="{{ name }}" id="{{ name }}">
+    {% for choice in choices %}<option value="{{ choice.0 }}">{{ choice.1 }}</option>{% endfor %}
+</select>
+
+<aside class="text-cta">
+{% if self.cta_link and self.cta_text %}<a href="{{ self.cta_link }}" class="btn btn-hw text-cta__cta">{{ self.cta_text }}</a>{% endif %}
+</aside>
+
+<div class="footer-cta">
+    <p class="footer-cta__title">{{ self.title }}</p>
+    {% if self.opens_modal and self.cta_text %}<a href="tel:{{ phone_number }}" class="btn btn-lg" role="button" aria-expanded="false">{{ self.cta_text }}</a>
+    {% elif self.cta_link and self.cta_text %}<a class="btn btn-lg" href="{{ self.cta_link }}">{{ self.cta_text }}</a>{% endif %}
+</div>
+
+<head>
+{% block meta-extras %}{% if page.noindex %}
+<meta name="robots" content="noindex">{% endif %}{% endblock %}
+</head>
+
+<a href="{{ url }}" class="ds-rounded-md ds-border ds-border-gray-030 ds-p-16 ds-flex ds-justify-between ds-items-center ds-flex-1 ds-transition hover:ds-bg-white ds-group" style="max-width: 50%;">
+    {% if is_prev %}{% include "firebolt/icons/clickable/chevron-left.svg" with class="ds-w-24 ds-h-24 ds-transition group-hover:-ds-translate-x-8" %}{% endif %}
+    <div class="ds-flex ds-flex-col {% if is_prev %}ds-items-end{% else %}ds-items-start{% endif %}">
+        <span class="ds-text-gray-110 ds-uppercase ds-text-12 ds-font-bold">{% if is_prev %}previous{% else %}next{% endif %}</span>
+        <span class="ds-text-24">{{ title }}</span>
+    </div>
+    {% if not is_prev %}{% include "firebolt/icons/clickable/chevron-right.svg" with class="ds-w-24 ds-h-24 ds-transition group-hover:ds-translate-x-8" %}{% endif %}
+</a>
+
+<div class="contact-info-column">
+    {% if contact.email %}<a href="mailto:{{ contact.email }}" target="blank_">{{ contact.email }}</a>{% endif %}
+    {% if contact.phone %}
+        <a class="contact-phone" href="tel:{{ contact.phone }}">{{ contact.phone }}</a>
+    {% endif %}
+</div>
+
+<p class="ds-text-14 sm:ds-text-16">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit
+    {% if formula_type == "foo" %} sed do eiusmod{% elif formula_type == "bar" %} tempor incididunt{% else %} ut labore et dolore{% endif %}
+</p>
+
+<div class="react-root">
+    {% block account-content %}<noscript>This page requires JavaScript to be enabled to work</noscript>{% endblock %}
+</div>

--- a/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.jinja
+++ b/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.jinja
@@ -27,6 +27,10 @@
 {% for drawback in offer_data.offer__drawbacks|underscore_separated_list %}<li>{{ drawback|safe  }}</li>{% endfor %}
 </div>
 
+<p>
+{% if alert_level == "low" %} the sky condition{% elif alert_level == "storm" %} the Storm warning{% else %} the Heatwave alert{% endif %}
+</p>
+
 <select name="{{ name }}" id="{{ name }}">
     {% for choice in choices %}<option value="{{ choice.0 }}">{{ choice.1 }}</option>{% endfor %}
 </select>
@@ -70,3 +74,29 @@
 <div class="react-root">
     {% block account-content %}<noscript>This page requires JavaScript to be enabled to work</noscript>{% endblock %}
 </div>
+
+# Inline elements in block context should preserve whitespace sensitivity
+<div>
+{% if forloop.first %}<strong>Used on the following active workflows:</strong>{% endif %}
+</div>
+
+# Text after jinja tag in block context should stay inline
+<div>
+<a href="#">{{ workflow.name }}</a>{% if not forloop.last %},{% endif %}
+</div>
+
+# blocktranslate should preserve leading/trailing spaces
+<h3>{% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}</h3>
+
+# Inline span in jinja block should stay on same line
+<h2><span>{{ heading }}</span>{% if is_required %}<span class="w-required-mark">*</span>{% endif %}</h2>
+<h2>
+    <span data-panel-heading-text>{{ heading }}</span>{% if is_required %}<span
+       class="w-required-mark"
+       data-panel-required
+    >*</span>{% endif %}
+</h2>
+
+{% if form.realm_subdomain.value() %}{{ form.realm_subdomain.value() }}.{%
+  endif
+%}{{ external_host }}

--- a/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
+++ b/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
@@ -1,0 +1,124 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<div class="contact-info-column">
+  {% if contact.email %}<a href="mailto:{{ contact.email }}">{{
+      contact.email
+    }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}"> {{ contact.email }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+  {% endif %}
+</div>
+<span class="contact-info-column">
+  {% if contact.email %}<a href="mailto:{{ contact.email }}">{{
+      contact.email
+    }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}"> {{ contact.email }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+  {% endif %}
+</span>
+
+# p hug the jinja tag here
+{%
+  if page_data.description
+%}<p class="ds-mb-0 ds-text-current-tint-110 ds-fgdgfdg">
+    AA page_data.description AA
+  </p>{% endif %}
+
+# but it's not required here because we are in a div context
+<div>
+  {%
+    if page_data.description
+  %}<p class="ds-mb-0 ds-text-current-tint-110 ds-fgdgfdg">
+      AA page_data.description AA
+    </p>{% endif %}
+</div>
+
+<div>
+  {%
+    for drawback in offer_data.offer__drawbacks|underscore_separated_list
+  %}<li>{{ drawback|safe }}</li>{% endfor %}
+</div>
+
+<select name="{{ name }}" id="{{ name }}">
+  {% for choice in choices %}<option value="{{ choice.0 }}">
+      {{ choice.1 }}
+    </option>{% endfor %}
+</select>
+
+<aside class="text-cta">
+  {% if self.cta_link and self.cta_text %}<a
+      href="{{ self.cta_link }}"
+      class="btn btn-hw text-cta__cta"
+    >{{ self.cta_text }}</a>{% endif %}
+</aside>
+
+<div class="footer-cta">
+  <p class="footer-cta__title">{{ self.title }}</p>
+  {% if self.opens_modal and self.cta_text %}<a
+      href="tel:{{ phone_number }}"
+      class="btn btn-lg"
+      role="button"
+      aria-expanded="false"
+    >{{ self.cta_text }}</a>
+  {% elif self.cta_link and self.cta_text %}<a
+      class="btn btn-lg"
+      href="{{ self.cta_link }}"
+    >{{ self.cta_text }}</a>{% endif %}
+</div>
+
+<head>
+  {% block meta-extras %}{% if page.noindex %}
+      <meta name="robots" content="noindex">{% endif %}{% endblock %}
+</head>
+
+<a
+  href="{{ url }}"
+  class="ds-rounded-md ds-border ds-border-gray-030 ds-p-16 ds-flex ds-justify-between ds-items-center ds-flex-1 ds-transition hover:ds-bg-white ds-group"
+  style="max-width: 50%;"
+>
+  {% if is_prev %}{%
+      include "firebolt/icons/clickable/chevron-left.svg" with class="ds-w-24 ds-h-24 ds-transition group-hover:-ds-translate-x-8"
+    %}{% endif %}
+  <div class="ds-flex ds-flex-col {% if is_prev %}ds-items-end{% else %}ds-items-start{% endif %}">
+    <span class="ds-text-gray-110 ds-uppercase ds-text-12 ds-font-bold">{%
+        if is_prev
+      %}previous{% else %}next{% endif %}</span>
+    <span class="ds-text-24">{{ title }}</span>
+  </div>
+  {% if not is_prev %}{%
+      include "firebolt/icons/clickable/chevron-right.svg" with class="ds-w-24 ds-h-24 ds-transition group-hover:ds-translate-x-8"
+    %}{% endif %}
+</a>
+
+<div class="contact-info-column">
+  {% if contact.email %}<a href="mailto:{{ contact.email }}" target="blank_">{{
+      contact.email
+    }}</a>{% endif %}
+  {% if contact.phone %}
+    <a class="contact-phone" href="tel:{{ contact.phone }}">{{
+      contact.phone
+    }}</a>
+  {% endif %}
+</div>
+
+<p class="ds-text-14 sm:ds-text-16">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit
+  {% if formula_type == "foo" %}
+    sed do eiusmod{% elif formula_type == "bar" %}
+    tempor incididunt{% else %}
+    ut labore et dolore{% endif %}
+</p>
+
+<div class="react-root">
+  {% block account-content %}<noscript>This page requires JavaScript to be
+      enabled to work</noscript>{% endblock %}
+</div>

--- a/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
+++ b/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
@@ -2,13 +2,15 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <div class="contact-info-column">
-  {% if contact.email %}<a href="mailto:{{ contact.email }}">{{
-      contact.email
-    }}</a>{% endif %}
   {% if contact.email %}
-    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>{% endif %}
+    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+  {% endif %}
   {% if contact.email %}
-    <a href="mailto:{{ contact.email }}"> {{ contact.email }}</a>{% endif %}
+    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+  {% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}"> {{ contact.email }}</a>
+  {% endif %}
   {% if contact.email %}
     <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
   {% endif %}

--- a/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
+++ b/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
@@ -37,49 +37,53 @@ source: markup_fmt/tests/fmt.rs
 
 # but it's not required here because we are in a div context
 <div>
-  {%
-    if page_data.description
-  %}<p class="ds-mb-0 ds-text-current-tint-110 ds-fgdgfdg">
+  {% if page_data.description %}
+    <p class="ds-mb-0 ds-text-current-tint-110 ds-fgdgfdg">
       AA page_data.description AA
-    </p>{% endif %}
+    </p>
+  {% endif %}
 </div>
 
 <div>
-  {%
-    for drawback in offer_data.offer__drawbacks|underscore_separated_list
-  %}<li>{{ drawback|safe }}</li>{% endfor %}
+  {% for drawback in offer_data.offer__drawbacks|underscore_separated_list %}
+    <li>{{ drawback|safe }}</li>
+  {% endfor %}
 </div>
 
 <select name="{{ name }}" id="{{ name }}">
-  {% for choice in choices %}<option value="{{ choice.0 }}">
-      {{ choice.1 }}
-    </option>{% endfor %}
+  {% for choice in choices %}
+    <option value="{{ choice.0 }}">{{ choice.1 }}</option>
+  {% endfor %}
 </select>
 
 <aside class="text-cta">
-  {% if self.cta_link and self.cta_text %}<a
-      href="{{ self.cta_link }}"
-      class="btn btn-hw text-cta__cta"
-    >{{ self.cta_text }}</a>{% endif %}
+  {% if self.cta_link and self.cta_text %}
+    <a href="{{ self.cta_link }}" class="btn btn-hw text-cta__cta">{{
+      self.cta_text
+    }}</a>
+  {% endif %}
 </aside>
 
 <div class="footer-cta">
   <p class="footer-cta__title">{{ self.title }}</p>
-  {% if self.opens_modal and self.cta_text %}<a
+  {% if self.opens_modal and self.cta_text %}
+    <a
       href="tel:{{ phone_number }}"
       class="btn btn-lg"
       role="button"
       aria-expanded="false"
     >{{ self.cta_text }}</a>
-  {% elif self.cta_link and self.cta_text %}<a
-      class="btn btn-lg"
-      href="{{ self.cta_link }}"
-    >{{ self.cta_text }}</a>{% endif %}
+  {% elif self.cta_link and self.cta_text %}
+    <a class="btn btn-lg" href="{{ self.cta_link }}">{{ self.cta_text }}</a>
+  {% endif %}
 </div>
 
 <head>
-  {% block meta-extras %}{% if page.noindex %}
-      <meta name="robots" content="noindex">{% endif %}{% endblock %}
+  {% block meta-extras %}
+    {% if page.noindex %}
+      <meta name="robots" content="noindex">
+    {% endif %}
+  {% endblock %}
 </head>
 
 <a
@@ -102,9 +106,9 @@ source: markup_fmt/tests/fmt.rs
 </a>
 
 <div class="contact-info-column">
-  {% if contact.email %}<a href="mailto:{{ contact.email }}" target="blank_">{{
-      contact.email
-    }}</a>{% endif %}
+  {% if contact.email %}
+    <a href="mailto:{{ contact.email }}" target="blank_">{{ contact.email }}</a>
+  {% endif %}
   {% if contact.phone %}
     <a class="contact-phone" href="tel:{{ contact.phone }}">{{
       contact.phone
@@ -115,12 +119,16 @@ source: markup_fmt/tests/fmt.rs
 <p class="ds-text-14 sm:ds-text-16">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit
   {% if formula_type == "foo" %}
-    sed do eiusmod{% elif formula_type == "bar" %}
-    tempor incididunt{% else %}
-    ut labore et dolore{% endif %}
+    sed do eiusmod
+  {% elif formula_type == "bar" %}
+    tempor incididunt
+  {% else %}
+    ut labore et dolore
+  {% endif %}
 </p>
 
 <div class="react-root">
-  {% block account-content %}<noscript>This page requires JavaScript to be
-      enabled to work</noscript>{% endblock %}
+  {% block account-content %}
+    <noscript>This page requires JavaScript to be enabled to work</noscript>
+  {% endblock %}
 </div>

--- a/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
+++ b/markup_fmt/tests/fmt/jinja/control-structure/nested-in-html.snap
@@ -50,6 +50,16 @@ source: markup_fmt/tests/fmt.rs
   {% endfor %}
 </div>
 
+<p>
+  {% if alert_level == "low" %}
+    the sky condition
+  {% elif alert_level == "storm" %}
+    the Storm warning
+  {% else %}
+    the Heatwave alert
+  {% endif %}
+</p>
+
 <select name="{{ name }}" id="{{ name }}">
   {% for choice in choices %}
     <option value="{{ choice.0 }}">{{ choice.1 }}</option>
@@ -132,3 +142,40 @@ source: markup_fmt/tests/fmt.rs
     <noscript>This page requires JavaScript to be enabled to work</noscript>
   {% endblock %}
 </div>
+
+# Inline elements in block context should preserve whitespace sensitivity
+<div>
+  {% if forloop.first %}
+    <strong>Used on the following active workflows:</strong>
+  {% endif %}
+</div>
+
+# Text after jinja tag in block context should stay inline
+<div>
+  <a href="#">{{ workflow.name }}</a>{% if not forloop.last %},{% endif %}
+</div>
+
+# blocktranslate should preserve leading/trailing spaces
+<h3>
+  {% blocktranslate with filter_title=title %} By {{ filter_title }}
+  {% endblocktranslate %}
+</h3>
+
+# Inline span in jinja block should stay on same line
+<h2>
+  <span>{{ heading }}</span>{% if is_required %}
+    <span class="w-required-mark">*</span>
+  {% endif %}
+</h2>
+<h2>
+  <span data-panel-heading-text>{{ heading }}</span>{% if is_required %}
+    <span
+      class="w-required-mark"
+      data-panel-required
+    >*</span>
+  {% endif %}
+</h2>
+
+{% if form.realm_subdomain.value() %}{{ form.realm_subdomain.value() }}.{%
+  endif
+%}{{ external_host }}

--- a/markup_fmt/tests/fmt/vento/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/vento/attributes/tag-or-block-as-attr.snap
@@ -2,19 +2,25 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <div
-  {{ if colored_with_absolute_dates }}colored-with-absolute-dates{{ /if }}
-  {{ if colored_with_days }}colored-with-days{{ /if }}
+  {{ if colored_with_absolute_dates }}
+    colored-with-absolute-dates
+  {{ /if }}
+  {{ if colored_with_days }}
+    colored-with-days
+  {{ /if }}
 >
 </div>
 
 <div
   class="flex"
-  {{ if colored_with_absolute_dates }}colored-with-absolute-dates{{ /if }}
+  {{ if colored_with_absolute_dates }}
+    colored-with-absolute-dates
+  {{ /if }}
   id="3"
 >
 </div>
 
-<div {{ if id }} id="{{ id }}" {{ /if }} class="flex gap-10"></div>
+<div {{ if id }}id="{{ id }}"{{ /if }} class="flex gap-10"></div>
 
 <div {{ if id != 1 }}class="active"{{ /if }}></div>
 
@@ -95,14 +101,18 @@ source: markup_fmt/tests/fmt.rs
 <div
   class="flex foo"
   id="index_id"
-  {{ if index_type == "foo" }}style="display: none"{{ /if }}
+  {{ if index_type == "foo" }}
+    style="display: none"
+  {{ /if }}
 >
   My text that should sometimes be hidden
 </div>
 
 <div
   data-toggle-mobile="true"
-  {{ if "adsl" not in connectivity_technology }}data-filter="fiber"{{ /if }}
+  {{ if "adsl" not in connectivity_technology }}
+    data-filter="fiber"
+  {{ /if }}
   class="foo bar baz yayayayayayaya"
 >
   Data attributes


### PR DESCRIPTION
Given this:

```jinja
<p>
{% if alert_level == "low" %} the sky condition{% elif alert_level == "storm" %} the Storm warning{% else %} the Heatwave alert{% endif %}
</p>
```

It was previously getting formatted to this:
```jinja
<p>
    {% if alert_level == "low" %}
        the sky condition{% elif alert_level == "storm" %}
        the Storm warning{% else %}
        the Heatwave alert{% endif %}
</p>
```

And will now respect the whitespace sensitivity of the parent node (the `p` tag here) and be formatted like so:

```jinja
<p>
    {% if alert_level == "low" %}
        the sky condition
    {% elif alert_level == "storm" %}
        the Storm warning
    {% else %}
        the Heatwave alert
    {% endif %}
</p>
```

I think it make sense because jinja block/tags basically disapear when rendered.

Test cases come from real world exemple were the formatting was weird previously.
You can see [the before in this commit](https://github.com/g-plane/markup_fmt/commit/0dc8eb79155c595b8126782555e5ba93709e7adb), and [the after in the last commit](https://github.com/g-plane/markup_fmt/commit/b7b0091491340bb96eb18f7a10b8468ab160a2f0)