### PR TITLE
Add `preserveUnquotedAttrs` option

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
   - [indentWidth](./config/indent-width.md)
   - [lineBreak](./config/line-break.md)
   - [quotes](./config/quotes.md)
+  - [preserveUnquotedAttrs](./config/preserve-unquoted-attrs.md)
   - [formatComments](./config/format-comments.md)
   - [scriptIndent](./config/script-indent.md)
   - [styleIndent](./config/style-indent.md)

--- a/docs/src/config/preserve-unquoted-attrs.md
+++ b/docs/src/config/preserve-unquoted-attrs.md
@@ -1,0 +1,17 @@
+# `preserveUnquotedAttrs`
+
+Control whether unquoted attribute values should remain unquoted in the output.
+
+Default option is `false`.
+
+## Example for `false`
+
+```html
+<c-button editable="True" count="42" />
+```
+
+## Example for `true`
+
+```html
+<c-button editable=True count=42 />
+```

--- a/dprint_plugin/src/config.rs
+++ b/dprint_plugin/src/config.rs
@@ -374,6 +374,12 @@ pub(crate) fn resolve_config(
                 true,
                 &mut diagnostics,
             ),
+            preserve_unquoted_attrs: get_value(
+                &mut config,
+                "preserveUnquotedAttrs",
+                false,
+                &mut diagnostics,
+            ),
             astro_attr_shorthand: get_nullable_value(
                 &mut config,
                 "astroAttrShorthand",

--- a/markup_fmt/src/config.rs
+++ b/markup_fmt/src/config.rs
@@ -223,6 +223,9 @@ pub struct LanguageOptions {
     )]
     pub angular_next_control_flow_same_line: bool,
 
+    #[cfg_attr(feature = "config_serde", serde(alias = "preserveUnquotedAttrs"))]
+    pub preserve_unquoted_attrs: bool,
+
     #[cfg_attr(feature = "config_serde", serde(alias = "scriptFormatter"))]
     pub script_formatter: Option<ScriptFormatter>,
 
@@ -275,6 +278,7 @@ impl Default for LanguageOptions {
             svelte_directive_shorthand: None,
             astro_attr_shorthand: None,
             angular_next_control_flow_same_line: true,
+            preserve_unquoted_attrs: false,
             script_formatter: None,
             ignore_comment_directive: "markup-fmt-ignore".into(),
             ignore_file_comment_directive: "markup-fmt-ignore-file".into(),

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1282,8 +1282,13 @@ impl<'s> DocGen<'s> for NativeAttribute<'s> {
                 quote = compute_attr_value_quote(&value, self.quote, ctx);
                 docs.extend(reflow_owned(&value));
             }
-            docs.insert(2, quote.clone());
-            docs.push(quote);
+            if ctx.options.preserve_unquoted_attrs && self.quote.is_none() {
+                docs.insert(2, Doc::nil());
+                docs.push(Doc::nil());
+            } else {
+                docs.insert(2, quote.clone());
+                docs.push(quote);
+            }
             Doc::list(docs)
         } else if matches!(ctx.language, Language::Svelte)
             && matches!(ctx.options.svelte_directive_shorthand, Some(false))

--- a/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/config.toml
+++ b/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/config.toml
@@ -1,0 +1,4 @@
+[default]
+
+[preserve-enabled]
+preserveUnquotedAttrs = true

--- a/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/fixture.default.snap
+++ b/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/fixture.default.snap
@@ -1,0 +1,23 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<c-button
+  editable="True"
+  :disabled="False"
+  count="42"
+  label="Click me"
+  disabled
+/>
+
+<c-layout.header
+  user_id="{{ user.id }}"
+  name="{{ user.name }}"
+  links_editable="True"
+  tags_editable="True"
+  editable
+  name_editable
+/>
+
+<div class="container" data-active="true" hidden>
+  <input type="text" value="placeholder">
+</div>

--- a/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/fixture.html
+++ b/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/fixture.html
@@ -1,0 +1,14 @@
+<c-button editable=True :disabled="False" count=42 label="Click me" disabled />
+
+<c-layout.header
+  user_id="{{ user.id }}"
+  name="{{ user.name }}"
+  links_editable=True
+  tags_editable=True
+  editable
+  name_editable
+/>
+
+<div class="container" data-active=true hidden>
+  <input type="text" value=placeholder>
+</div>

--- a/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/fixture.preserve-enabled.snap
+++ b/markup_fmt/tests/fmt/html/attributes/preserve-unquoted/fixture.preserve-enabled.snap
@@ -1,0 +1,17 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<c-button editable=True :disabled="False" count=42 label="Click me" disabled />
+
+<c-layout.header
+  user_id="{{ user.id }}"
+  name="{{ user.name }}"
+  links_editable=True
+  tags_editable=True
+  editable
+  name_editable
+/>
+
+<div class="container" data-active=true hidden>
+  <input type="text" value=placeholder>
+</div>


### PR DESCRIPTION
## Summary

Adds a `preserveUnquotedAttrs` boolean option (default: `false`) that preserves
unquoted HTML attribute values in the formatted output.

When enabled, `prop=True` stays as `prop=True` instead of being normalized to
`prop="True"`. Already-quoted values and boolean attributes without values are
unaffected.

## Motivation

Unquoted attribute values are [valid HTML per spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2).
Some frameworks use them to pass non-string types. For example:

- [Django Cotton](https://django-cotton.com/) (component library for Django)
  uses `editable=True` to pass a Python boolean, while `editable="True"` passes
  the string `"True"`, which has different runtime semantics.
- Cotton 2.6+ explicitly added support for this shorthand syntax to align with
  Django's native template tag conventions.

The parser already stores whether a value was unquoted (`NativeAttribute.quote`
is `None`). This change makes the printer respect that signal when the option
is enabled.

## Changes

- `config.rs`: Add `preserve_unquoted_attrs: bool` to `LanguageOptions`
- `printer.rs`: Skip quote insertion when the option is enabled and
  `self.quote.is_none()`
- `dprint_plugin/src/config.rs`: Wire the option through the dprint plugin
- `docs/src/config/preserve-unquoted-attrs.md`: Config documentation
- `docs/src/SUMMARY.md`: Add to table of contents
- Snapshot tests with `config.toml` variants (default vs enabled)

Context: UnknownPlatypus/djangofmt#271