### PR TITLE
feat: replace external syntax error position manually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "insta",
  "itertools",
  "memchr",
+ "regex",
  "serde",
  "similar-asserts",
  "tiny_pretty",
@@ -803,10 +804,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "regex-automata"
-version = "0.4.9"
+name = "regex"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/dprint_plugin/tests/integration.rs
+++ b/dprint_plugin/tests/integration.rs
@@ -10,7 +10,7 @@ use std::{borrow::Cow, fs, io, path::Path};
 
 #[test]
 fn integration_with_dprint_ts_snapshot() {
-    fn format_with_dprint_ts(input: &str, path: &Path) -> Result<String, FormatError<Error>> {
+    fn format_with_dprint_ts(input: &str, path: &Path) -> Result<String, FormatError> {
         let mut options = match fs::read_to_string(path.with_extension("toml")) {
             Ok(file) => toml::from_str::<FormatOptions>(&file).unwrap(),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Default::default(),

--- a/markup_fmt/Cargo.toml
+++ b/markup_fmt/Cargo.toml
@@ -10,9 +10,11 @@ exclude = ["/tests"]
 
 [dependencies]
 aho-corasick = "1.1"
+anyhow = "1.0"
 css_dataset = { version = "0.4", default-features = false, features = ["tags"] }
 itertools = "0.14"
 memchr = "2.7"
+regex = "1.12"
 serde = { version = "1.0", optional = true }
 tiny_pretty = { version = "0.2", features = ["unicode-width"] }
 

--- a/markup_fmt/README.md
+++ b/markup_fmt/README.md
@@ -12,7 +12,7 @@ assert_eq!("<div class=\"container\"></div>\n", &format_text(
     "<div class=container></div>",
     Language::Html,
     &options,
-    |code, _| Ok::<_, std::convert::Infallible>(code.into()),
+    |code, _| Ok(code.into()),
 ).unwrap());
 ```
 
@@ -30,19 +30,18 @@ assert!(matches!(
         "<div>",
         Language::Html,
         &options,
-        |code, _| Ok::<_, std::convert::Infallible>(code.into()),
+        |code, _| Ok(code.into()),
     ).unwrap_err(),
     FormatError::Syntax(SyntaxError { .. })
 ));
 ```
 
-External formatter can return [`Err`] as well.
+External formatter can return `anyhow::Error`.
 This error will be aggregated and returned in [`FormatError::External`]:
 
 ```rust
+use anyhow::Error;
 use markup_fmt::{config::FormatOptions, format_text, FormatError, Language};
-
-struct ExternalFormatterError;
 
 let options = FormatOptions::default();
 assert!(matches!(
@@ -50,7 +49,7 @@ assert!(matches!(
         "<script>a</script>",
         Language::Html,
         &options,
-        |_, _| Err(ExternalFormatterError),
+        |_, _| Err(Error::msg("external formatter error")),
     ).unwrap_err(),
     FormatError::External(errors) if !errors.is_empty()
 ));

--- a/markup_fmt/examples/fmt.rs
+++ b/markup_fmt/examples/fmt.rs
@@ -1,5 +1,5 @@
 use markup_fmt::{config::FormatOptions, detect_language, format_text};
-use std::{convert::Infallible, env, fs, io};
+use std::{env, fs, io};
 
 fn main() -> anyhow::Result<()> {
     let file_path = env::args().nth(1).unwrap();
@@ -16,9 +16,7 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let formatted = format_text(&code, language, &options, |code, _| {
-        Ok::<_, Infallible>(code.into())
-    })?;
+    let formatted = format_text(&code, language, &options, |code, _| Ok(code.into()))?;
     print!("{formatted}");
     Ok(())
 }

--- a/markup_fmt/src/ctx.rs
+++ b/markup_fmt/src/ctx.rs
@@ -142,17 +142,16 @@ where
         attr: bool,
         start: usize,
     ) -> Result<String, Error> {
-        if code.trim().is_empty() {
+        let code = code.trim_ascii();
+        if code.is_empty() {
             Ok(String::new())
         } else {
             // Trim original code before sending it to the external formatter.
             // This makes sure the code will be trimmed
             // though external formatter isn't available.
-            let preprocessed = code.trim_start();
-            let will_add_brackets =
-                preprocessed.starts_with('{') || preprocessed.starts_with("...");
+            let will_add_brackets = code.starts_with('{') || code.starts_with("...");
             let wrapped = if will_add_brackets {
-                &format!("[{}]", code.trim())
+                &format!("[{code}]")
             } else {
                 code
             };
@@ -168,8 +167,8 @@ where
             )?;
             let mut formatted =
                 formatted.trim_matches(|c: char| c.is_ascii_whitespace() || c == ';');
-            formatted = trim_delim(preprocessed, formatted, '[', ']');
-            formatted = trim_delim(preprocessed, formatted, '(', ')');
+            formatted = trim_delim(code, formatted, '[', ']');
+            formatted = trim_delim(code, formatted, '(', ')');
             if will_add_brackets {
                 formatted = formatted.trim_ascii_end().trim_end_matches(',');
             }
@@ -178,10 +177,11 @@ where
     }
 
     pub(crate) fn format_binding(&mut self, code: &str, start: usize) -> String {
-        if code.trim().is_empty() {
+        let code = code.trim_ascii();
+        if code.is_empty() {
             String::new()
         } else {
-            let wrapped = format!("let {} = 0", code.trim());
+            let wrapped = format!("let {code} = 0");
             let formatted = self.format_with_external_formatter(
                 &wrapped,
                 Hints {
@@ -202,10 +202,11 @@ where
     }
 
     pub(crate) fn format_type_params(&mut self, code: &str, start: usize) -> String {
-        if code.trim().is_empty() {
+        let code = code.trim_ascii();
+        if code.is_empty() {
             String::new()
         } else {
-            let wrapped = format!("type T<{}> = 0", code.trim());
+            let wrapped = format!("type T<{code}> = 0");
             let formatted = self.format_with_external_formatter(
                 &wrapped,
                 Hints {
@@ -228,7 +229,8 @@ where
     }
 
     pub(crate) fn format_stmt_header(&mut self, keyword: &str, code: &str) -> String {
-        if code.trim().is_empty() {
+        let code = code.trim_ascii();
+        if code.is_empty() {
             String::new()
         } else {
             let wrapped = format!("{keyword} ({code}) {{}}");

--- a/markup_fmt/src/ctx.rs
+++ b/markup_fmt/src/ctx.rs
@@ -4,14 +4,20 @@ use crate::{
     helpers,
     state::State,
 };
+use anyhow::Error;
 use memchr::memchr;
-use std::borrow::Cow;
+use regex::{Captures, Regex};
+use std::{borrow::Cow, sync::LazyLock};
 
 const QUOTES: [&str; 3] = ["\"", "\"", "'"];
 
-pub(crate) struct Ctx<'b, E, F>
+static RE_LINE_COLUMN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:[Ll]ine\s*(\d+),?\s*[Cc]ol(?:umn)?\s*(\d+))|:(\d+):(\d+)").unwrap()
+});
+
+pub(crate) struct Ctx<'b, F>
 where
-    F: for<'a> FnMut(&'a str, Hints<'b>) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints<'b>) -> Result<Cow<'a, str>, Error>,
 {
     pub(crate) source: &'b str,
     pub(crate) language: Language,
@@ -19,12 +25,12 @@ where
     pub(crate) print_width: usize,
     pub(crate) options: &'b LanguageOptions,
     pub(crate) external_formatter: F,
-    pub(crate) external_formatter_errors: Vec<E>,
+    pub(crate) external_formatter_errors: Vec<Error>,
 }
 
-impl<'b, E, F> Ctx<'b, E, F>
+impl<'b, F> Ctx<'b, F>
 where
-    F: for<'a> FnMut(&'a str, Hints<'b>) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints<'b>) -> Result<Cow<'a, str>, Error>,
 {
     pub(crate) fn script_indent(&self) -> bool {
         match self.language {
@@ -135,7 +141,7 @@ where
         code: &str,
         attr: bool,
         start: usize,
-    ) -> Result<String, E> {
+    ) -> Result<String, Error> {
         if code.trim().is_empty() {
             Ok(String::new())
         } else {
@@ -146,19 +152,9 @@ where
             let will_add_brackets =
                 preprocessed.starts_with('{') || preprocessed.starts_with("...");
             let wrapped = if will_add_brackets {
-                self.source
-                    .get(0..start.saturating_sub(1))
-                    .unwrap_or_default()
-                    .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                    + "["
-                    + code.trim()
-                    + "]"
+                &format!("[{}]", code.trim())
             } else {
-                self.source
-                    .get(0..start)
-                    .unwrap_or_default()
-                    .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                    + code
+                code
             };
             let formatted = self.try_format_with_external_formatter(
                 wrapped,
@@ -168,6 +164,7 @@ where
                     attr,
                     ext: "tsx",
                 },
+                start,
             )?;
             let mut formatted =
                 formatted.trim_matches(|c: char| c.is_ascii_whitespace() || c == ';');
@@ -184,22 +181,16 @@ where
         if code.trim().is_empty() {
             String::new()
         } else {
-            let wrapped = self
-                .source
-                .get(0..start.saturating_sub(4))
-                .unwrap_or_default()
-                .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                + "let "
-                + code.trim()
-                + " = 0";
+            let wrapped = format!("let {} = 0", code.trim());
             let formatted = self.format_with_external_formatter(
-                wrapped,
+                &wrapped,
                 Hints {
                     print_width: self.print_width,
                     indent_level: 0,
                     attr: false,
                     ext: "ts",
                 },
+                start,
             );
             let formatted = formatted.trim_matches(|c: char| c.is_ascii_whitespace() || c == ';');
             formatted
@@ -214,22 +205,16 @@ where
         if code.trim().is_empty() {
             String::new()
         } else {
-            let wrapped = self
-                .source
-                .get(0..start.saturating_sub(7))
-                .unwrap_or_default()
-                .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                + "type T<"
-                + code.trim()
-                + "> = 0";
+            let wrapped = format!("type T<{}> = 0", code.trim());
             let formatted = self.format_with_external_formatter(
-                wrapped,
+                &wrapped,
                 Hints {
                     print_width: self.print_width,
                     indent_level: 0,
                     attr: true,
                     ext: "ts",
                 },
+                start,
             );
             let formatted = formatted.trim_matches(|c: char| c.is_ascii_whitespace() || c == ';');
             formatted
@@ -248,13 +233,14 @@ where
         } else {
             let wrapped = format!("{keyword} ({code}) {{}}");
             let formatted = self.format_with_external_formatter(
-                wrapped,
+                &wrapped,
                 Hints {
                     print_width: self.print_width,
                     indent_level: 0,
                     attr: false,
                     ext: "js",
                 },
+                0,
             );
             formatted
                 .strip_prefix(keyword)
@@ -290,19 +276,16 @@ where
         lang: &'b str,
         start: usize,
         state: &State,
-    ) -> Result<Cow<'a, str>, E> {
+    ) -> Result<Cow<'a, str>, Error> {
         self.try_format_with_external_formatter(
-            self.source
-                .get(0..start)
-                .unwrap_or_default()
-                .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                + code,
+            code,
             Hints {
                 print_width: self.print_width,
                 indent_level: state.indent_level,
                 attr: false,
                 ext: lang,
             },
+            start,
         )
     }
 
@@ -314,14 +297,7 @@ where
         state: &State,
     ) -> Cow<'a, str> {
         self.format_with_external_formatter(
-            "\n".repeat(
-                self.source
-                    .get(0..start)
-                    .unwrap_or_default()
-                    .lines()
-                    .count()
-                    .saturating_sub(1),
-            ) + code,
+            code,
             Hints {
                 print_width: self
                     .print_width
@@ -335,22 +311,20 @@ where
                 attr: false,
                 ext: if lang == "postcss" { "css" } else { lang },
             },
+            start,
         )
     }
 
     pub(crate) fn format_style_attr(&mut self, code: &str, start: usize, state: &State) -> String {
         self.format_with_external_formatter(
-            self.source
-                .get(0..start)
-                .unwrap_or_default()
-                .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                + code,
+            code,
             Hints {
                 print_width: u16::MAX as usize,
                 indent_level: state.indent_level,
                 attr: true,
                 ext: "css",
             },
+            start,
         )
         .trim()
         .to_owned()
@@ -363,11 +337,7 @@ where
         state: &State,
     ) -> Cow<'a, str> {
         self.format_with_external_formatter(
-            self.source
-                .get(0..start)
-                .unwrap_or_default()
-                .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                + code,
+            code,
             Hints {
                 print_width: self
                     .print_width
@@ -381,6 +351,7 @@ where
                 attr: false,
                 ext: "json",
             },
+            start,
         )
     }
 
@@ -392,11 +363,7 @@ where
         state: &State,
     ) -> String {
         self.format_with_external_formatter(
-            self.source
-                .get(0..start)
-                .unwrap_or_default()
-                .replace(|c: char| !c.is_ascii_whitespace(), " ")
-                + code,
+            code,
             Hints {
                 print_width: self
                     .print_width
@@ -409,6 +376,7 @@ where
                     "markup-fmt-jinja-stmt"
                 },
             },
+            start,
         )
         .trim_ascii()
         .to_owned()
@@ -416,12 +384,12 @@ where
 
     fn format_with_external_formatter<'a>(
         &mut self,
-        code: String,
+        code: &'a str,
         hints: Hints<'b>,
+        start: usize,
     ) -> Cow<'a, str> {
-        match (self.external_formatter)(&code, hints) {
-            Ok(Cow::Owned(formatted)) => Cow::from(formatted),
-            Ok(Cow::Borrowed(..)) => Cow::from(code),
+        match self.try_format_with_external_formatter(code, hints, start) {
+            Ok(formatted) => formatted,
             Err(e) => {
                 self.external_formatter_errors.push(e);
                 code.into()
@@ -431,13 +399,45 @@ where
 
     fn try_format_with_external_formatter<'a>(
         &mut self,
-        code: String,
+        code: &'a str,
         hints: Hints<'b>,
-    ) -> Result<Cow<'a, str>, E> {
-        match (self.external_formatter)(&code, hints) {
+        start: usize,
+    ) -> Result<Cow<'a, str>, Error> {
+        match (self.external_formatter)(code, hints) {
             Ok(Cow::Owned(formatted)) => Ok(Cow::from(formatted)),
             Ok(Cow::Borrowed(..)) => Ok(Cow::from(code)),
-            Err(e) => Err(e),
+            Err(e) => {
+                let msg = e.to_string();
+                let (start_line, start_col) = helpers::pos_to_line_col(self.source, start);
+                let msg = RE_LINE_COLUMN
+                    .replace_all(&msg, |captures: &Captures| {
+                        captures
+                            .get(1)
+                            .or_else(|| captures.get(3))
+                            .zip(captures.get(2).or_else(|| captures.get(4)))
+                            .and_then(|(line, col)| {
+                                Some((
+                                    msg.get(..line.start())?,
+                                    msg.get(line.range())
+                                        .and_then(|line| line.parse::<usize>().ok())?,
+                                    msg.get(line.end()..col.start())?,
+                                    msg.get(col.range())
+                                        .and_then(|col| col.parse::<usize>().ok())?,
+                                    msg.get(col.end()..)?,
+                                ))
+                            })
+                            .map(|(prefix, line, mid, col, suffix)| {
+                                format!(
+                                    "{prefix}{}{mid}{}{suffix}",
+                                    (start_line + line).saturating_sub(1),
+                                    start_col + col
+                                )
+                            })
+                            .unwrap_or_else(|| msg.clone())
+                    })
+                    .to_string();
+                Err(Error::msg(msg))
+            }
         }
     }
 }

--- a/markup_fmt/src/error.rs
+++ b/markup_fmt/src/error.rs
@@ -1,4 +1,5 @@
-use std::{borrow::Cow, error::Error, fmt};
+use anyhow::Error;
+use std::{borrow::Cow, fmt};
 
 #[derive(Clone, Debug)]
 /// Syntax error when parsing tags, not `<script>` or `<style>` tag.
@@ -136,22 +137,19 @@ impl fmt::Display for SyntaxError {
     }
 }
 
-impl Error for SyntaxError {}
+impl std::error::Error for SyntaxError {}
 
 #[derive(Debug)]
 /// The error type for markup_fmt.
-pub enum FormatError<E> {
+pub enum FormatError {
     /// Syntax error when parsing tags.
     Syntax(SyntaxError),
     /// Error from external formatter, for example,
     /// there're errors when formatting the `<script>` or `<style>` tag.
-    External(Vec<E>),
+    External(Vec<Error>),
 }
 
-impl<E> fmt::Display for FormatError<E>
-where
-    E: fmt::Display,
-{
+impl fmt::Display for FormatError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FormatError::Syntax(e) => e.fmt(f),
@@ -166,4 +164,4 @@ where
     }
 }
 
-impl<E> Error for FormatError<E> where E: Error {}
+impl std::error::Error for FormatError {}

--- a/markup_fmt/src/helpers.rs
+++ b/markup_fmt/src/helpers.rs
@@ -315,7 +315,7 @@ pub(crate) fn pos_to_line_col(source: &str, pos: usize) -> (usize, usize) {
         },
     );
     match search {
-        ControlFlow::Break((line, offset)) => (line, pos - offset + 1),
+        ControlFlow::Break((line, offset)) => (line, pos - offset.max(pos)),
         ControlFlow::Continue((line, _)) => (line, 0),
     }
 }

--- a/markup_fmt/src/lib.rs
+++ b/markup_fmt/src/lib.rs
@@ -11,6 +11,7 @@ mod state;
 
 use crate::{config::FormatOptions, ctx::Ctx, parser::Parser, printer::DocGen, state::State};
 pub use crate::{ctx::Hints, error::*, parser::Language};
+use anyhow::Error;
 use std::{borrow::Cow, path::Path};
 use tiny_pretty::{IndentKind, PrintOptions};
 
@@ -37,7 +38,7 @@ use tiny_pretty::{IndentKind, PrintOptions};
 ///     code,
 ///     Language::Html,
 ///     &Default::default(),
-///     |code, _| Ok::<_, std::convert::Infallible>(code.into()),
+///     |code, _| Ok(code.into()),
 /// ).unwrap();
 /// ```
 ///
@@ -46,14 +47,14 @@ use tiny_pretty::{IndentKind, PrintOptions};
 /// - The first argument is code that needs formatting.
 /// - The second argument is hints which contains useful information for external formatters,
 ///   such as file extension and print width.
-pub fn format_text<E, F>(
+pub fn format_text<F>(
     code: &str,
     language: Language,
     options: &FormatOptions,
     external_formatter: F,
-) -> Result<String, FormatError<E>>
+) -> Result<String, FormatError>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     let mut parser = Parser::new(code, language);
     let ast = parser.parse_root().map_err(FormatError::Syntax)?;
@@ -142,7 +143,6 @@ pub fn detect_language(path: impl AsRef<Path>) -> Option<Language> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::Infallible;
 
     #[test]
     fn mjs() {
@@ -153,7 +153,7 @@ mod tests {
             &Default::default(),
             |code, hints| {
                 ext = Some(hints.ext.to_owned());
-                Ok::<_, Infallible>(Cow::from(code))
+                Ok(Cow::from(code))
             },
         );
         assert_eq!(ext.as_deref(), Some("mjs"));
@@ -168,7 +168,7 @@ mod tests {
             &Default::default(),
             |code, hints| {
                 ext = Some(hints.ext.to_owned());
-                Ok::<_, Infallible>(Cow::from(code))
+                Ok(Cow::from(code))
             },
         );
         assert_eq!(ext.as_deref(), Some("mts"));
@@ -183,7 +183,7 @@ mod tests {
             &Default::default(),
             |code, hints| {
                 ext = Some(hints.ext.to_owned());
-                Ok::<_, Infallible>(Cow::from(code))
+                Ok(Cow::from(code))
             },
         );
         assert_eq!(ext.as_deref(), Some("jsx"));
@@ -198,7 +198,7 @@ mod tests {
             &Default::default(),
             |code, hints| {
                 ext = Some(hints.ext.to_owned());
-                Ok::<_, Infallible>(Cow::from(code))
+                Ok(Cow::from(code))
             },
         );
         assert_eq!(ext.as_deref(), Some("tsx"));

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -7,20 +7,21 @@ use crate::{
     parser::parse_as_interpolated,
     state::State,
 };
+use anyhow::Error;
 use itertools::{EitherOrBoth, Itertools};
 use std::borrow::Cow;
 use tiny_pretty::Doc;
 
 pub(super) trait DocGen<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>;
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>;
 }
 
 impl<'s> DocGen<'s> for AngularElseIf<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("@else if ("));
@@ -41,9 +42,9 @@ impl<'s> DocGen<'s> for AngularElseIf<'s> {
 }
 
 impl<'s> DocGen<'s> for AngularFor<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("@for ("));
@@ -86,9 +87,9 @@ impl<'s> DocGen<'s> for AngularFor<'s> {
 }
 
 impl<'s> DocGen<'s> for AngularGenericBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("@"));
@@ -109,9 +110,9 @@ impl<'s> DocGen<'s> for AngularGenericBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for Vec<AngularGenericBlock<'s>> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let next_block_ws = if ctx.options.angular_next_control_flow_same_line {
             Doc::space()
@@ -129,9 +130,9 @@ impl<'s> DocGen<'s> for Vec<AngularGenericBlock<'s>> {
 }
 
 impl<'s> DocGen<'s> for AngularIf<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let next_cf_ws = if ctx.options.angular_next_control_flow_same_line {
             Doc::space()
@@ -174,9 +175,9 @@ impl<'s> DocGen<'s> for AngularIf<'s> {
 }
 
 impl<'s> DocGen<'s> for AngularInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{{")
             .append(Doc::line_or_space())
@@ -194,9 +195,9 @@ impl<'s> DocGen<'s> for AngularInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for AngularLet<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("@let ")
             .append(Doc::text(self.name))
@@ -207,9 +208,9 @@ impl<'s> DocGen<'s> for AngularLet<'s> {
 }
 
 impl<'s> DocGen<'s> for AngularSwitch<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("@switch ("));
@@ -228,9 +229,9 @@ impl<'s> DocGen<'s> for AngularSwitch<'s> {
 }
 
 impl<'s> DocGen<'s> for AngularSwitchArm<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text(format!("@{}", self.keyword)));
@@ -251,9 +252,9 @@ impl<'s> DocGen<'s> for AngularSwitchArm<'s> {
 }
 
 impl<'s> DocGen<'s> for AstroAttribute<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let expr_code = ctx.format_expr(self.expr.0, false, self.expr.1);
         let expr = Doc::text("{")
@@ -278,9 +279,9 @@ impl<'s> DocGen<'s> for AstroAttribute<'s> {
 }
 
 impl<'s> DocGen<'s> for AstroExpr<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let indent_width = ctx.indent_width;
 
@@ -356,9 +357,9 @@ impl<'s> DocGen<'s> for AstroExpr<'s> {
 }
 
 impl<'s> DocGen<'s> for Attribute<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         match self {
             Attribute::Native(native_attribute) => native_attribute.doc(ctx, state),
@@ -376,9 +377,9 @@ impl<'s> DocGen<'s> for Attribute<'s> {
 }
 
 impl<'s> DocGen<'s> for Cdata<'s> {
-    fn doc<E, F>(&self, _: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, _: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("<![CDATA[")
             .concat(reflow_raw(self.raw))
@@ -387,9 +388,9 @@ impl<'s> DocGen<'s> for Cdata<'s> {
 }
 
 impl<'s> DocGen<'s> for Comment<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if ctx.options.format_comments {
             Doc::text("<!--")
@@ -408,9 +409,9 @@ impl<'s> DocGen<'s> for Comment<'s> {
 }
 
 impl<'s> DocGen<'s> for Doctype<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         use crate::config::DoctypeKeywordCase;
 
@@ -431,9 +432,9 @@ impl<'s> DocGen<'s> for Doctype<'s> {
 }
 
 impl<'s> DocGen<'s> for Element<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let tag_name = self
             .tag_name
@@ -904,9 +905,9 @@ impl<'s> DocGen<'s> for Element<'s> {
 }
 
 impl<'s> DocGen<'s> for FrontMatter<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if matches!(ctx.language, Language::Astro) {
             let formatted = ctx.format_script(self.raw, "tsx", self.start, state);
@@ -924,9 +925,9 @@ impl<'s> DocGen<'s> for FrontMatter<'s> {
 }
 
 impl<'s> DocGen<'s> for JinjaBlock<'s, Attribute<'s>> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::list(
             self.body
@@ -947,9 +948,9 @@ impl<'s> DocGen<'s> for JinjaBlock<'s, Attribute<'s>> {
 }
 
 impl<'s> DocGen<'s> for JinjaBlock<'s, Node<'s>> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::list(
             self.body
@@ -966,9 +967,9 @@ impl<'s> DocGen<'s> for JinjaBlock<'s, Node<'s>> {
 }
 
 impl<'s> DocGen<'s> for JinjaComment<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if ctx.options.format_comments {
             Doc::text("{#")
@@ -987,9 +988,9 @@ impl<'s> DocGen<'s> for JinjaComment<'s> {
 }
 
 impl<'s> DocGen<'s> for JinjaInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{{")
             .append(if self.trim_prev {
@@ -1015,9 +1016,9 @@ impl<'s> DocGen<'s> for JinjaInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for JinjaTag<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let (prefix, content) = if let Some(content) = self.content.strip_prefix('-') {
             ("-", content)
@@ -1053,9 +1054,9 @@ impl<'s> DocGen<'s> for JinjaTag<'s> {
 }
 
 impl<'s> DocGen<'s> for JsComment<'s> {
-    fn doc<E, F>(&self, _: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, _: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if self.block {
             Doc::text("/*")
@@ -1068,9 +1069,9 @@ impl<'s> DocGen<'s> for JsComment<'s> {
 }
 
 impl<'s> DocGen<'s> for MustacheBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::list(
             self.controls
@@ -1104,9 +1105,9 @@ impl<'s> DocGen<'s> for MustacheBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for MustacheInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if self.content.starts_with('!') {
             Doc::text("{{")
@@ -1134,9 +1135,9 @@ impl<'s> DocGen<'s> for MustacheInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for NativeAttribute<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let name = Doc::text(self.name);
         if let Some((value, value_start)) = self.value {
@@ -1306,9 +1307,9 @@ impl<'s> DocGen<'s> for NativeAttribute<'s> {
 }
 
 impl<'s> DocGen<'s> for NodeKind<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         match self {
             NodeKind::AngularFor(angular_for) => angular_for.doc(ctx, state),
@@ -1361,9 +1362,9 @@ impl<'s> DocGen<'s> for NodeKind<'s> {
 }
 
 impl<'s> DocGen<'s> for Root<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let is_whole_document_like = self.children.iter().any(|child| match &child.kind {
             NodeKind::Doctype(..) => true,
@@ -1395,9 +1396,9 @@ impl<'s> DocGen<'s> for Root<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteAtTag<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{@")
             .append(Doc::text(self.name))
@@ -1411,9 +1412,9 @@ impl<'s> DocGen<'s> for SvelteAtTag<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteAttribute<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let expr_code = ctx.format_expr(self.expr.0, false, self.expr.1);
         let expr = Doc::text("{")
@@ -1461,9 +1462,9 @@ impl<'s> DocGen<'s> for SvelteAttribute<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteAttachment<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let expr_code = ctx.format_expr(self.expr.0, false, self.expr.1);
         Doc::text("{@attach ")
@@ -1473,9 +1474,9 @@ impl<'s> DocGen<'s> for SvelteAttachment<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteAwaitBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut head = Vec::with_capacity(5);
         head.push(Doc::text("{#await "));
@@ -1527,9 +1528,9 @@ impl<'s> DocGen<'s> for SvelteAwaitBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteCatchBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let children = format_control_structure_block_children(&self.children, ctx, state);
         if let Some((binding, start)) = self.binding {
@@ -1544,9 +1545,9 @@ impl<'s> DocGen<'s> for SvelteCatchBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteEachBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("{#each "));
@@ -1590,9 +1591,9 @@ impl<'s> DocGen<'s> for SvelteEachBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteElseIfBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{:else if ")
             .append(Doc::text(ctx.format_expr(self.expr.0, false, self.expr.1)))
@@ -1606,9 +1607,9 @@ impl<'s> DocGen<'s> for SvelteElseIfBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteIfBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("{#if "));
@@ -1639,9 +1640,9 @@ impl<'s> DocGen<'s> for SvelteIfBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{")
             .append(Doc::line_or_nil())
@@ -1657,9 +1658,9 @@ impl<'s> DocGen<'s> for SvelteInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteKeyBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{#key ")
             .append(Doc::text(ctx.format_expr(self.expr.0, false, self.expr.1)))
@@ -1674,9 +1675,9 @@ impl<'s> DocGen<'s> for SvelteKeyBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteSnippetBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let wrapped = format!("function {}{{}}", self.signature.0);
         let formatted = ctx.format_script(&wrapped, "ts", self.signature.1, state);
@@ -1702,9 +1703,9 @@ impl<'s> DocGen<'s> for SvelteSnippetBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for SvelteThenBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         let mut docs = Vec::with_capacity(5);
         docs.push(Doc::text("{:then"));
@@ -1723,9 +1724,9 @@ impl<'s> DocGen<'s> for SvelteThenBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for TextNode<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if ctx.language == Language::Xml {
             if self.raw.chars().all(|c| c.is_ascii_whitespace()) {
@@ -1752,9 +1753,9 @@ impl<'s> DocGen<'s> for TextNode<'s> {
 }
 
 impl<'s> DocGen<'s> for VentoBlock<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::list(
             self.body
@@ -1766,9 +1767,9 @@ impl<'s> DocGen<'s> for VentoBlock<'s> {
 }
 
 impl<'s> DocGen<'s> for VentoComment<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         if ctx.options.format_comments {
             Doc::text("{{#")
@@ -1787,9 +1788,9 @@ impl<'s> DocGen<'s> for VentoComment<'s> {
 }
 
 impl<'s> DocGen<'s> for VentoEval<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{{>")
             .append(Doc::line_or_space())
@@ -1807,9 +1808,9 @@ impl<'s> DocGen<'s> for VentoEval<'s> {
 }
 
 impl<'s> DocGen<'s> for VentoInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{{")
             .append(if self.trim_prev {
@@ -1842,9 +1843,9 @@ impl<'s> DocGen<'s> for VentoInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for VentoTag<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{{")
             .append(if self.trim_prev {
@@ -1952,9 +1953,9 @@ impl<'s> DocGen<'s> for VentoTag<'s> {
 }
 
 impl<'s> DocGen<'s> for VentoTagOrChildren<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         match self {
             VentoTagOrChildren::Tag(tag) => tag.doc(ctx, state),
@@ -1966,9 +1967,9 @@ impl<'s> DocGen<'s> for VentoTagOrChildren<'s> {
 }
 
 impl<'s> DocGen<'s> for VueDirective<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         use crate::config::{VBindStyle, VOnStyle};
 
@@ -2125,9 +2126,9 @@ impl<'s> DocGen<'s> for VueDirective<'s> {
 }
 
 impl<'s> DocGen<'s> for VueInterpolation<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, _: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, _: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("{{")
             .append(Doc::line_or_space())
@@ -2143,9 +2144,9 @@ impl<'s> DocGen<'s> for VueInterpolation<'s> {
 }
 
 impl<'s> DocGen<'s> for XmlDecl<'s> {
-    fn doc<E, F>(&self, ctx: &mut Ctx<'s, E, F>, state: &State<'s>) -> Doc<'s>
+    fn doc<F>(&self, ctx: &mut Ctx<'s, F>, state: &State<'s>) -> Doc<'s>
     where
-        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+        F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
     {
         Doc::text("<?xml")
             .concat(
@@ -2296,9 +2297,9 @@ fn is_multi_line_attr(attr: &Attribute) -> bool {
     }
 }
 
-fn should_ignore_node<'s, E, F>(index: usize, nodes: &[Node], ctx: &Ctx<'s, E, F>) -> bool
+fn should_ignore_node<'s, F>(index: usize, nodes: &[Node], ctx: &Ctx<'s, F>) -> bool
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     match index.checked_sub(1).and_then(|i| nodes.get(i)) {
         Some(Node {
@@ -2322,9 +2323,9 @@ where
         _ => false,
     }
 }
-fn has_ignore_directive<'s, E, F>(comment: &Comment, ctx: &Ctx<'s, E, F>) -> bool
+fn has_ignore_directive<'s, F>(comment: &Comment, ctx: &Ctx<'s, F>) -> bool
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     comment
         .raw
@@ -2407,13 +2408,13 @@ fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes) -> Doc<'_> {
         .append(quote)
 }
 
-fn format_children_with_inserting_linebreak<'s, E, F>(
+fn format_children_with_inserting_linebreak<'s, F>(
     children: &[Node<'s>],
-    ctx: &mut Ctx<'s, E, F>,
+    ctx: &mut Ctx<'s, F>,
     state: &State<'s>,
 ) -> Doc<'s>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     Doc::list(
         children
@@ -2496,13 +2497,13 @@ fn is_text_like(node: &Node, language: Language) -> bool {
     }
 }
 
-fn format_children_without_inserting_linebreak<'s, E, F>(
+fn format_children_without_inserting_linebreak<'s, F>(
     children: &[Node<'s>],
-    ctx: &mut Ctx<'s, E, F>,
+    ctx: &mut Ctx<'s, F>,
     state: &State<'s>,
 ) -> Doc<'s>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     Doc::list(
         children
@@ -2570,13 +2571,13 @@ fn extract_slot_name(arg_and_modifiers: Option<&str>) -> &str {
         .unwrap_or("default")
 }
 
-fn get_v_slot_style_option<'s, E, F>(
+fn get_v_slot_style_option<'s, F>(
     slot: &'s str,
-    ctx: &Ctx<'s, E, F>,
+    ctx: &Ctx<'s, F>,
     state: &State<'s>,
 ) -> Option<VSlotStyle>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     let option = if state
         .current_tag_name
@@ -2658,15 +2659,15 @@ fn format_ws_insensitive_trailing_ws<'s>(children: &[Node<'s>]) -> Doc<'s> {
         _ => Doc::line_or_nil(),
     }
 }
-fn format_v_for<'s, E, F>(
+fn format_v_for<'s, F>(
     left: &str,
     delimiter: &'static str,
     right: &str,
     start: usize,
-    ctx: &mut Ctx<'s, E, F>,
+    ctx: &mut Ctx<'s, F>,
 ) -> String
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     let left = ctx.format_expr(left, false, start);
     let right = ctx.format_expr(right, false, start + 4);
@@ -2680,13 +2681,13 @@ where
     }
 }
 
-fn format_control_structure_block_children<'s, E, F>(
+fn format_control_structure_block_children<'s, F>(
     children: &[Node<'s>],
-    ctx: &mut Ctx<'s, E, F>,
+    ctx: &mut Ctx<'s, F>,
     state: &State<'s>,
 ) -> Doc<'s>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     match children {
         [
@@ -2704,14 +2705,14 @@ where
     }
 }
 
-fn format_vento_stmt_header<'s, E, F>(
+fn format_vento_stmt_header<'s, F>(
     tag_keyword: &'static str,
     fake_keyword: &'static str,
     code: &'s str,
-    ctx: &mut Ctx<'s, E, F>,
+    ctx: &mut Ctx<'s, F>,
 ) -> Doc<'s>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     Doc::text(tag_keyword)
         .append(Doc::space())
@@ -2725,13 +2726,13 @@ where
 ///
 /// This will try to respect the configured `quotes` but might change it
 /// to ensure the result is valid html.
-fn compute_attr_value_quote<'s, E, F>(
+fn compute_attr_value_quote<'s, F>(
     attr_value: &str,
     initial_quote: Option<char>,
-    ctx: &mut Ctx<'s, E, F>,
+    ctx: &mut Ctx<'s, F>,
 ) -> Doc<'s>
 where
-    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, E>,
+    F: for<'a> FnMut(&'a str, Hints) -> Result<Cow<'a, str>, Error>,
 {
     let has_single = attr_value.contains('\'');
     let has_double = attr_value.contains('"');

--- a/markup_fmt/tests/fmt.rs
+++ b/markup_fmt/tests/fmt.rs
@@ -1,6 +1,6 @@
 use insta::{Settings, assert_snapshot, glob};
 use markup_fmt::{Language, config::FormatOptions, detect_language, format_text};
-use std::{collections::HashMap, convert::Infallible, fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 
 #[test]
 fn fmt_snapshot() {
@@ -39,21 +39,17 @@ fn run_format_test(
     options: &FormatOptions,
     language: Language,
 ) -> String {
-    let output = format_text(input, language, options, |code, _| {
-        Ok::<_, Infallible>(code.into())
-    })
-    .map_err(|err| format!("failed to format '{}': {:?}", path.display(), err))
-    .unwrap();
-    let regression_format = format_text(&output, language, options, |code, _| {
-        Ok::<_, Infallible>(code.into())
-    })
-    .map_err(|err| {
-        format!(
-            "syntax error in stability test '{}': {err:?}",
-            path.display(),
-        )
-    })
-    .unwrap();
+    let output = format_text(input, language, options, |code, _| Ok(code.into()))
+        .map_err(|err| format!("failed to format '{}': {:?}", path.display(), err))
+        .unwrap();
+    let regression_format = format_text(&output, language, options, |code, _| Ok(code.into()))
+        .map_err(|err| {
+            format!(
+                "syntax error in stability test '{}': {err:?}",
+                path.display(),
+            )
+        })
+        .unwrap();
     similar_asserts::assert_eq!(
         output,
         regression_format,


### PR DESCRIPTION
## Advantages

- No need to construct large strings.
- Syntax error position will still be mapped to original position in HTML or template.

## Disadvantages

- API changed: Error type from external formatter must be `anyhow::Error` instead of generic `E`, but this should be okay because most users will consume the built wasm instead of calling from Rust. Even though, most errors type can be converted to `anyhow::Error`.
- Error message recognition rule are encoded in a regex, and it may not be able to handle any external formatters. Of course, plugins listed in dprint.dev are supported.

## Result

Given the code below:

```html
<script lang="ts">


     {
</script>

<style>

    {
</style>

<script type="application/json">

   {
</script>
```

errors will be like:

```
Expected '}', got '<eof>' at file:///file.tsExpected '}', got '<eof>' at file:///file.ts:4:6

       {
       ~

       {
       ~
syntax error at syntax error at line 9, col 5: CSS rule is expected: CSS rule is expected
Line 14, column 4: Unterminated object

     {: Unterminated object

     {
```

Close #221 

@UnknownPlatypus @sergey-kintsel