### PR TITLE
fix: pos_to_line_col always reports column 0

### DIFF
--- a/markup_fmt/src/helpers.rs
+++ b/markup_fmt/src/helpers.rs
@@ -315,7 +315,21 @@ pub(crate) fn pos_to_line_col(source: &str, pos: usize) -> (usize, usize) {
         },
     );
     match search {
-        ControlFlow::Break((line, offset)) => (line, pos - offset.max(pos)),
+        ControlFlow::Break((line, offset)) => (line, pos - offset + 1),
         ControlFlow::Continue((line, _)) => (line, 0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn pos_to_line_col() {
+        let source = "abc\ndef\nghi";
+        // Positions whose line is followed by a later newline go through the
+        // `Break` arm, which must report a non-zero column.
+        assert_eq!(super::pos_to_line_col(source, 0), (1, 1));
+        assert_eq!(super::pos_to_line_col(source, 2), (1, 3));
+        assert_eq!(super::pos_to_line_col(source, 4), (2, 2));
+        assert_eq!(super::pos_to_line_col(source, 6), (2, 4));
     }
 }


### PR DESCRIPTION
In `helpers::pos_to_line_col`, the `Break` arm computes the column as:

```rust
ControlFlow::Break((line, offset)) => (line, pos - offset.max(pos)),
```

On the `Break` arm, `offset` is the byte offset of the previous newline, which
is always `<= pos`. Therefore `offset.max(pos)` is always `pos`, and the column
is always `0`, regardless of the actual position on the line.

This regressed in #223, which changed the expression from `pos - offset + 1` to
`pos - offset.max(pos)`. Since the subtraction can never underflow on this arm
(`offset <= pos`), the `max` guard was unnecessary and produced an incorrect
result. As a consequence, every syntax-error message now reports `column 0`
(e.g. `expected close tag for opening tag <h1> from line 4, column 0` instead of
`... column 2`).

This PR restores `pos - offset + 1` and adds a unit test that pins the column to
a non-zero value for positions taking the `Break` arm. The test fails on the
current code (`(1, 0)` instead of `(1, 1)`) and passes with the fix.