### PR TITLE
Fix infinite indent in `<script>` with unknown type

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -679,7 +679,11 @@ impl<'s> DocGen<'s> for Element<'s> {
                         }
                         _ => None,
                     });
-                    match type_attr.as_deref() {
+                    let is_script_indent = ctx.script_indent();
+                    if is_script_indent {
+                        state.indent_level += 1;
+                    }
+                    let doc = match type_attr.as_deref() {
                         Some(
                             "module"
                             | "application/javascript"
@@ -694,10 +698,6 @@ impl<'s> DocGen<'s> for Element<'s> {
                             | "text/babel",
                         )
                         | None => {
-                            let is_script_indent = ctx.script_indent();
-                            if is_script_indent {
-                                state.indent_level += 1;
-                            }
                             let lang = self
                                 .attrs
                                 .iter()
@@ -739,18 +739,11 @@ impl<'s> DocGen<'s> for Element<'s> {
                             } else {
                                 ctx.format_script(text_node.raw, lang, text_node.start, &state)
                             };
-                            let doc = if matches!(
-                                ctx.options.script_formatter,
-                                Some(ScriptFormatter::Dprint)
-                            ) {
+                            if matches!(ctx.options.script_formatter, Some(ScriptFormatter::Dprint))
+                            {
                                 Doc::hard_line().concat(reflow_owned(formatted.trim()))
                             } else {
                                 Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true))
-                            };
-                            if is_script_indent {
-                                docs.push(doc.nest(ctx.indent_width));
-                            } else {
-                                docs.push(doc);
                             }
                         }
                         Some(
@@ -761,14 +754,16 @@ impl<'s> DocGen<'s> for Element<'s> {
                             | "speculationrules",
                         ) => {
                             let formatted = ctx.format_json(text_node.raw, text_node.start, &state);
-                            docs.push(
-                                Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true)),
-                            );
+                            Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true))
                         }
                         Some(..) => {
-                            docs.push(Doc::hard_line());
-                            docs.extend(reflow_raw(text_node.raw.trim_matches('\n')));
+                            Doc::hard_line().concat(reflow_with_indent(text_node.raw.trim(), true))
                         }
+                    };
+                    if is_script_indent {
+                        docs.push(doc.nest(ctx.indent_width));
+                    } else {
+                        docs.push(doc);
                     }
                     docs.push(Doc::hard_line());
                 }

--- a/markup_fmt/tests/fmt/html/script/config.toml
+++ b/markup_fmt/tests/fmt/html/script/config.toml
@@ -1,0 +1,5 @@
+[script-indent-false]
+scriptIndent = false
+
+[script-indent-true]
+scriptIndent = true

--- a/markup_fmt/tests/fmt/html/script/nested-non-js-type.html
+++ b/markup_fmt/tests/fmt/html/script/nested-non-js-type.html
@@ -1,0 +1,5 @@
+<div>
+    <script type="text/html">
+        <p>x</p>
+    </script>
+</div>

--- a/markup_fmt/tests/fmt/html/script/nested-non-js-type.html
+++ b/markup_fmt/tests/fmt/html/script/nested-non-js-type.html
@@ -2,4 +2,8 @@
     <script type="text/html">
         <p>x</p>
     </script>
+
+    <script type="application/json">
+        {"ssrData":{"items":[1,2,3]}}
+    </script>
 </div>

--- a/markup_fmt/tests/fmt/html/script/nested-non-js-type.script-indent-false.snap
+++ b/markup_fmt/tests/fmt/html/script/nested-non-js-type.script-indent-false.snap
@@ -1,0 +1,12 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<div>
+  <script type="text/html">
+  <p>x</p>
+  </script>
+
+  <script type="application/json">
+  {"ssrData":{"items":[1,2,3]}}
+  </script>
+</div>

--- a/markup_fmt/tests/fmt/html/script/nested-non-js-type.script-indent-true.snap
+++ b/markup_fmt/tests/fmt/html/script/nested-non-js-type.script-indent-true.snap
@@ -1,0 +1,12 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<div>
+  <script type="text/html">
+    <p>x</p>
+  </script>
+
+  <script type="application/json">
+    {"ssrData":{"items":[1,2,3]}}
+  </script>
+</div>

--- a/markup_fmt/tests/fmt/html/whitespace/snippets.snap
+++ b/markup_fmt/tests/fmt/html/whitespace/snippets.snap
@@ -39,24 +39,24 @@ source: markup_fmt/tests/fmt.rs
 <p><span>X</span>   or   <span>Y</span></p><p>X   or   Y</p>
 <!-- U+2005 -->
 <script type="text/unknown" lang="unknown">
-         // comment
-          // comment
-          // comment
-          // comment
+// comment
+// comment
+// comment
+// comment
 </script>
 <!-- U+005F -->
 <script type="text/unknown" lang="unknown">
-    _    // comment
-          // comment
-          // comment
-          // comment
+_    // comment
+// comment
+// comment
+// comment
 </script>
 <!-- U+0020 -->
 <script type="text/unknown" lang="unknown">
-         // comment
-          // comment
-          // comment
-          // comment
+// comment
+// comment
+// comment
+// comment
 </script>
 
 <!-- U+2005 -->


### PR DESCRIPTION
There is a stability issue when formatting a script with unknown type -> [playground](https://dprint.dev/playground/#code/DwEwlgbgfAUABAuwDOBjATmADgFzjgTywFMBeAIh2IA8cB6ACxwFsAbc2RLpLKa4Or3iIBaTLlgDw0IA/plugin/markup_fmt)

```html
<div>
    <script type="text/html">
        <p>x</p>
    </script>
</div>
```
After the first run:

```html
<div>
    <script type="text/html">
            <p>x</p>
    
    </script>
</div>
```

And after the second run:

```html
<div>
    <script type="text/html">
                <p>x</p>
    
    
    </script>
</div>
```

On each format:
- It adds an extra indent before
- it adds an extra newline after

I tried a fix but I'm not super happy with it because it re-indent the script and I have no idea if it's safe for <script> with unknown type.

Maybe you'll have better ideas @g-plane 