### PR TITLE
Respect `script_indent` in `<script type="application/json">`

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -679,6 +679,10 @@ impl<'s> DocGen<'s> for Element<'s> {
                         }
                         _ => None,
                     });
+                    let is_script_indent = ctx.script_indent();
+                    if is_script_indent {
+                        state.indent_level += 1;
+                    }
                     match type_attr.as_deref() {
                         Some(
                             "module"
@@ -694,10 +698,6 @@ impl<'s> DocGen<'s> for Element<'s> {
                             | "text/babel",
                         )
                         | None => {
-                            let is_script_indent = ctx.script_indent();
-                            if is_script_indent {
-                                state.indent_level += 1;
-                            }
                             let lang = self
                                 .attrs
                                 .iter()
@@ -761,9 +761,13 @@ impl<'s> DocGen<'s> for Element<'s> {
                             | "speculationrules",
                         ) => {
                             let formatted = ctx.format_json(text_node.raw, text_node.start, &state);
-                            docs.push(
-                                Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true)),
-                            );
+                            let doc =
+                                Doc::hard_line().concat(reflow_with_indent(formatted.trim(), true));
+                            if is_script_indent {
+                                docs.push(doc.nest(ctx.indent_width));
+                            } else {
+                                docs.push(doc);
+                            }
                         }
                         Some(..) => {
                             docs.extend(reflow_raw(text_node.raw.trim_ascii_end()));

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.both.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.both.snap
@@ -18,5 +18,8 @@ source: markup_fmt/tests/fmt.rs
     <script>
       window.addEventListener('load', () => {})
     </script>
+    <script type="application/json">
+      {"ssrData":{"items":[1,2,3]}}
+    </script>
   </body>
 </html>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.html
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.html
@@ -11,5 +11,6 @@
       /* --- */
     </style>
     <script>window.addEventListener('load', () => {})</script>
+    <script type="application/json">{"ssrData":{"items":[1,2,3]}}</script>
   </body>
 </html>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.override-script.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.override-script.snap
@@ -18,5 +18,8 @@ source: markup_fmt/tests/fmt.rs
     <script>
       window.addEventListener('load', () => {})
     </script>
+    <script type="application/json">
+      {"ssrData":{"items":[1,2,3]}}
+    </script>
   </body>
 </html>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.override-style.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.override-style.snap
@@ -18,5 +18,8 @@ source: markup_fmt/tests/fmt.rs
     <script>
     window.addEventListener('load', () => {})
     </script>
+    <script type="application/json">
+    {"ssrData":{"items":[1,2,3]}}
+    </script>
   </body>
 </html>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.script.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.script.snap
@@ -18,5 +18,8 @@ source: markup_fmt/tests/fmt.rs
     <script>
       window.addEventListener('load', () => {})
     </script>
+    <script type="application/json">
+      {"ssrData":{"items":[1,2,3]}}
+    </script>
   </body>
 </html>

--- a/markup_fmt/tests/fmt/html/script-style-indent/example.style.snap
+++ b/markup_fmt/tests/fmt/html/script-style-indent/example.style.snap
@@ -18,5 +18,8 @@ source: markup_fmt/tests/fmt.rs
     <script>
     window.addEventListener('load', () => {})
     </script>
+    <script type="application/json">
+    {"ssrData":{"items":[1,2,3]}}
+    </script>
   </body>
 </html>


### PR DESCRIPTION
While working on #228, I noticed we respect the script indent for javascript but not json.

This is safe to do because the content of these elements is treated as a data block (parsed as JSON, never executed) per the [HTML spec](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element) and JSON treats whitespace between tokens as insignificant, so adding/removing leading/trailing indentation can't change the parsed value —[ RFC 8259](https://www.rfc-editor.org/rfc/rfc8259#section-2).

I've added a new test case to showcase that

