### PR TITLE
Indent multi-line attribute values one level deeper

### DIFF
--- a/dprint_plugin/src/lib.rs
+++ b/dprint_plugin/src/lib.rs
@@ -122,7 +122,10 @@ pub fn build_additional_config(hints: Hints, config: &FormatOptions) -> ConfigKe
                     config.language.script_formatter,
                     Some(ScriptFormatter::Biome)
                 ) {
+                    // dprint-plugin-biome renamed this key to `javascript.quoteStyle`;
+                    // keep the old name for older versions of that plugin.
                     additional_config.insert("javascriptQuoteStyle".into(), "single".into());
+                    additional_config.insert("javascript.quoteStyle".into(), "single".into());
                 } else {
                     additional_config.insert("quoteStyle".into(), "alwaysSingle".into());
                 }
@@ -133,6 +136,7 @@ pub fn build_additional_config(hints: Hints, config: &FormatOptions) -> ConfigKe
                     Some(ScriptFormatter::Biome)
                 ) {
                     additional_config.insert("javascriptQuoteStyle".into(), "double".into());
+                    additional_config.insert("javascript.quoteStyle".into(), "double".into());
                 } else {
                     additional_config.insert("quoteStyle".into(), "alwaysDouble".into());
                 }

--- a/dprint_plugin/tests/integration/dprint_ts/basic.vue.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/basic.vue.snap
@@ -40,9 +40,9 @@ function greet(msg: string) {
   />
   <div
     :style="{
-        'height': '200px',
-        /* position: relative; */
-      }"
+      'height': '200px',
+      /* position: relative; */
+    }"
   >
   </div>
 </template>

--- a/dprint_plugin/tests/integration/dprint_ts/basic.vue.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/basic.vue.snap
@@ -36,13 +36,13 @@ function greet(msg: string) {
   <button :class="" @click="">{{  }}{{ /**/ }}</button>
   <v-list-item
     @click="$triggerDialog('editScreen', { screenId: screen.id });
-    close()"
+      close()"
   />
   <div
     :style="{
-      'height': '200px',
-      /* position: relative; */
-    }"
+        'height': '200px',
+        /* position: relative; */
+      }"
   >
   </div>
 </template>

--- a/dprint_plugin/tests/integration/dprint_ts/issue-212.vue.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/issue-212.vue.snap
@@ -19,4 +19,14 @@ line two keeps raw template literal content`
       : someOtherValueThatIsLongEnoughToKeepTheExpressionBrokenAcrossLines"
   >
   </div>
+  <u-page-header
+    :title="page.title"
+    :ui="{
+      root: 'border-b border-default',
+      description: 'mt-1 text-muted',
+      headline: 'text-sm uppercase tracking-wide text-primary',
+    }"
+    @close="emit('close');
+      reset()"
+  ></u-page-header>
 </template>

--- a/dprint_plugin/tests/integration/dprint_ts/issue-212.vue.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/issue-212.vue.snap
@@ -1,0 +1,22 @@
+---
+source: dprint_plugin/tests/integration.rs
+---
+<template>
+  <u-tooltip
+    :text="row.original.acknowledgement.severity.value === notice.severity.value
+      ? undefined
+      : `The acknowledged severity differs from the notice's, which was ${notice.severity.label}.`"
+  >
+    <u-badge
+      :label="row.original.acknowledgement.severity.label"
+      :color="row.original.acknowledgement.severity.color"
+    />
+  </u-tooltip>
+  <div
+    :data-raw="cond
+        ? `line one
+line two keeps raw template literal content`
+        : someOtherValueThatIsLongEnoughToKeepTheExpressionBrokenAcrossLines"
+  >
+  </div>
+</template>

--- a/dprint_plugin/tests/integration/dprint_ts/issue-212.vue.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/issue-212.vue.snap
@@ -14,9 +14,9 @@ source: dprint_plugin/tests/integration.rs
   </u-tooltip>
   <div
     :data-raw="cond
-        ? `line one
+      ? `line one
 line two keeps raw template literal content`
-        : someOtherValueThatIsLongEnoughToKeepTheExpressionBrokenAcrossLines"
+      : someOtherValueThatIsLongEnoughToKeepTheExpressionBrokenAcrossLines"
   >
   </div>
 </template>

--- a/dprint_plugin/tests/integration/issue-212.vue
+++ b/dprint_plugin/tests/integration/issue-212.vue
@@ -16,4 +16,14 @@ line two keeps raw template literal content`
           : someOtherValueThatIsLongEnoughToKeepTheExpressionBrokenAcrossLines"
   >
   </div>
+  <u-page-header
+    :title="page.title"
+    :ui="{
+      root: 'border-b border-default',
+      description: 'mt-1 text-muted',
+      headline: 'text-sm uppercase tracking-wide text-primary',
+    }"
+    @close='emit("close");
+    reset();'
+  ></u-page-header>
 </template>

--- a/dprint_plugin/tests/integration/issue-212.vue
+++ b/dprint_plugin/tests/integration/issue-212.vue
@@ -1,0 +1,19 @@
+<template>
+  <u-tooltip
+    :text="row.original.acknowledgement.severity.value === notice.severity.value
+    ? undefined
+    : `The acknowledged severity differs from the notice's, which was ${notice.severity.label}.`"
+  >
+    <u-badge
+      :label="row.original.acknowledgement.severity.label"
+      :color="row.original.acknowledgement.severity.color"
+    />
+  </u-tooltip>
+  <div
+    :data-raw="cond
+          ? `line one
+line two keeps raw template literal content`
+          : someOtherValueThatIsLongEnoughToKeepTheExpressionBrokenAcrossLines"
+  >
+  </div>
+</template>

--- a/markup_fmt/src/helpers.rs
+++ b/markup_fmt/src/helpers.rs
@@ -175,17 +175,72 @@ pub(crate) static UNESCAPING_AC: LazyLock<AhoCorasick> =
     LazyLock::new(|| AhoCorasick::new(["&quot;", "&#x22;", "&#x27;"]).unwrap());
 
 pub(crate) fn detect_indent(s: &str) -> usize {
+    let mut pair_stack = Vec::new();
     s.lines()
-        .skip(if s.starts_with([' ', '\t']) { 0 } else { 1 })
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| {
-            line.as_bytes()
-                .iter()
-                .take_while(|byte| byte.is_ascii_whitespace())
-                .count()
+        .enumerate()
+        .filter_map(|(i, line)| {
+            // Leading whitespace inside a template literal is content, not indentation.
+            let in_template_literal = matches!(pair_stack.last(), Some('`'));
+            update_pair_stack(&mut pair_stack, line);
+            if in_template_literal
+                || line.trim().is_empty()
+                || i == 0 && !s.starts_with([' ', '\t'])
+            {
+                None
+            } else {
+                Some(
+                    line.as_bytes()
+                        .iter()
+                        .take_while(|byte| byte.is_ascii_whitespace())
+                        .count(),
+                )
+            }
         })
         .min()
         .unwrap_or_default()
+}
+
+/// Carries open string/template literal/brace/comment delimiters across the lines
+/// of an embedded expression; a '`' on top means "currently inside a template literal".
+pub(crate) fn update_pair_stack(pair_stack: &mut Vec<char>, line: &str) {
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '`' | '\'' | '"' => {
+                let last = pair_stack.last();
+                if last.is_some_and(|last| *last == c) {
+                    pair_stack.pop();
+                } else if matches!(last, Some('$' | '{') | None) {
+                    pair_stack.push(c);
+                }
+            }
+            '$' if matches!(pair_stack.last(), Some('`'))
+                && chars.next_if(|next| *next == '{').is_some() =>
+            {
+                pair_stack.push('$');
+            }
+            '{' if !matches!(pair_stack.last(), Some('`' | '\'' | '"' | '/')) => {
+                pair_stack.push('{');
+            }
+            '}' if matches!(pair_stack.last(), Some('$' | '{')) => {
+                pair_stack.pop();
+            }
+            '/' if !matches!(pair_stack.last(), Some('\'' | '"' | '`')) => {
+                if chars.next_if(|next| *next == '*').is_some() {
+                    pair_stack.push('*');
+                } else if chars.next_if(|next| *next == '/').is_some() {
+                    break;
+                }
+            }
+            '*' if chars.next_if(|next| *next == '/').is_some() => {
+                pair_stack.pop();
+            }
+            '\\' if matches!(pair_stack.last(), Some('\'' | '"' | '`')) => {
+                chars.next();
+            }
+            _ => {}
+        }
+    }
 }
 
 pub(crate) fn pascal2kebab(s: &'_ str) -> Cow<'_, str> {

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2207,45 +2207,7 @@ fn reflow_with_indent<'i, 'o: 'i>(
             s
         };
         let should_keep_raw = matches!(pair_stack.last(), Some('`'));
-
-        let mut chars = s.chars().peekable();
-        while let Some(c) = chars.next() {
-            match c {
-                '`' | '\'' | '"' => {
-                    let last = pair_stack.last();
-                    if last.is_some_and(|last| *last == c) {
-                        pair_stack.pop();
-                    } else if matches!(last, Some('$' | '{') | None) {
-                        pair_stack.push(c);
-                    }
-                }
-                '$' if matches!(pair_stack.last(), Some('`'))
-                    && chars.next_if(|next| *next == '{').is_some() =>
-                {
-                    pair_stack.push('$');
-                }
-                '{' if !matches!(pair_stack.last(), Some('`' | '\'' | '"' | '/')) => {
-                    pair_stack.push('{');
-                }
-                '}' if matches!(pair_stack.last(), Some('$' | '{')) => {
-                    pair_stack.pop();
-                }
-                '/' if !matches!(pair_stack.last(), Some('\'' | '"' | '`')) => {
-                    if chars.next_if(|next| *next == '*').is_some() {
-                        pair_stack.push('*');
-                    } else if chars.next_if(|next| *next == '/').is_some() {
-                        break;
-                    }
-                }
-                '*' if chars.next_if(|next| *next == '/').is_some() => {
-                    pair_stack.pop();
-                }
-                '\\' if matches!(pair_stack.last(), Some('\'' | '"' | '`')) => {
-                    chars.next();
-                }
-                _ => {}
-            }
-        }
+        helpers::update_pair_stack(&mut pair_stack, s);
 
         [
             if i == 0 {

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -1296,7 +1296,7 @@ impl<'s> DocGen<'s> for NativeAttribute<'s> {
                 let value = format!("{{{binding_name}}}");
                 name.append(Doc::char('='))
                     .append(if ctx.options.strict_svelte_attr {
-                        format_attr_value(value, &ctx.options.quotes)
+                        format_attr_value(value, &ctx.options.quotes, ctx.indent_width)
                     } else {
                         Doc::text(value)
                     })
@@ -1442,6 +1442,7 @@ impl<'s> DocGen<'s> for SvelteAttribute<'s> {
                         name.append(format_attr_value(
                             format!("{{{expr_code}}}"),
                             &ctx.options.quotes,
+                            ctx.indent_width,
                         ))
                     } else {
                         name.append(expr)
@@ -1454,6 +1455,7 @@ impl<'s> DocGen<'s> for SvelteAttribute<'s> {
                 name.append(format_attr_value(
                     format!("{{{expr_code}}}"),
                     &ctx.options.quotes,
+                    ctx.indent_width,
                 ))
             } else {
                 name.append(expr)
@@ -2114,14 +2116,22 @@ impl<'s> DocGen<'s> for VueDirective<'s> {
                 && matches!(self.arg_and_modifiers, Some(arg_and_modifiers) if arg_and_modifiers == value))
             {
                 docs.push(Doc::char('='));
-                docs.push(format_attr_value(value, &ctx.options.quotes));
+                docs.push(format_attr_value(
+                    value,
+                    &ctx.options.quotes,
+                    ctx.indent_width,
+                ));
             }
         } else if matches!(ctx.options.v_bind_same_name_short_hand, Some(false))
             && is_v_bind
             && let Some(arg_and_modifiers) = self.arg_and_modifiers
         {
             docs.push(Doc::char('='));
-            docs.push(format_attr_value(arg_and_modifiers, &ctx.options.quotes));
+            docs.push(format_attr_value(
+                arg_and_modifiers,
+                &ctx.options.quotes,
+                ctx.indent_width,
+            ));
         }
 
         Doc::list(docs)
@@ -2394,7 +2404,7 @@ fn has_two_more_non_text_children(children: &[Node], language: Language) -> bool
         > 1
 }
 
-fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes) -> Doc<'_> {
+fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes, indent_width: usize) -> Doc<'_> {
     let value = value.as_ref();
     let quote = if value.contains('"') {
         Doc::char('\'')
@@ -2407,7 +2417,7 @@ fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes) -> Doc<'_> {
     };
     quote
         .clone()
-        .concat(reflow_with_indent(value, true))
+        .append(Doc::list(reflow_with_indent(value, true).collect()).nest(indent_width))
         .append(quote)
 }
 

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2377,9 +2377,24 @@ fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes, indent_width: usiz
     } else {
         Doc::char('\'')
     };
+    // A value whose last line opens with a closing delimiter is anchored by the
+    // bracket on its first line, like `:ui="{ ... }"`, and its inner lines already
+    // read one level deep, so indenting further would fight the conventions of
+    // Prettier and eslint-plugin-vue. Only unanchored continuations (ternaries,
+    // additional statements) need the extra level to stay clear of the column
+    // where attribute names live.
+    let is_anchored = value
+        .lines()
+        .next_back()
+        .is_some_and(|line| matches!(line.trim_start().chars().next(), Some('}' | ')' | ']')));
+    let content = Doc::list(reflow_with_indent(value, true).collect());
     quote
         .clone()
-        .append(Doc::list(reflow_with_indent(value, true).collect()).nest(indent_width))
+        .append(if is_anchored {
+            content
+        } else {
+            content.nest(indent_width)
+        })
         .append(quote)
 }
 

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2145,9 +2145,9 @@ impl<'s> DocGen<'s> for VueInterpolation<'s> {
     {
         Doc::text("{{")
             .append(Doc::line_or_space())
-            .concat(reflow_with_indent(
+            .append(reflow_expr_with_indent(
                 &ctx.format_expr(self.expr, false, self.start),
-                true,
+                ctx.indent_width,
             ))
             .nest(ctx.indent_width)
             .append(Doc::line_or_space())
@@ -2377,25 +2377,49 @@ fn format_attr_value(value: impl AsRef<str>, quotes: &Quotes, indent_width: usiz
     } else {
         Doc::char('\'')
     };
-    // A value whose last line opens with a closing delimiter is anchored by the
-    // bracket on its first line, like `:ui="{ ... }"`, and its inner lines already
-    // read one level deep, so indenting further would fight the conventions of
-    // Prettier and eslint-plugin-vue. Only unanchored continuations (ternaries,
-    // additional statements) need the extra level to stay clear of the column
-    // where attribute names live.
-    let is_anchored = value
-        .lines()
-        .next_back()
-        .is_some_and(|line| matches!(line.trim_start().chars().next(), Some('}' | ')' | ']')));
-    let content = Doc::list(reflow_with_indent(value, true).collect());
     quote
         .clone()
-        .append(if is_anchored {
-            content
-        } else {
-            content.nest(indent_width)
-        })
+        .append(reflow_expr_with_indent(value, indent_width))
         .append(quote)
+}
+
+/// Reflows a formatted embedded expression, giving continuation lines one extra
+/// level of indentation unless the expression is anchored: when a line at the
+/// expression's base indentation opens with a closing delimiter, like the brace
+/// in `:ui="{ ... }"`, the bracket pair already structures the block and inner
+/// lines already read one level deep, so indenting further would fight the
+/// conventions of Prettier and eslint-plugin-vue, and would break the closer
+/// out of line with its opener. Only unanchored continuations (ternaries,
+/// additional statements) need the extra level to stay clear of the column
+/// where attribute names or sibling elements live.
+fn reflow_expr_with_indent<'i, 'o: 'i>(expr: &'i str, indent_width: usize) -> Doc<'o> {
+    let base_indent = helpers::detect_indent(expr);
+    let mut pair_stack = Vec::new();
+    let mut lines = expr.lines();
+    if let Some(first_line) = lines.next() {
+        helpers::update_pair_stack(&mut pair_stack, first_line);
+    }
+    let mut is_anchored = false;
+    for line in lines {
+        let in_template_literal = matches!(pair_stack.last(), Some('`'));
+        helpers::update_pair_stack(&mut pair_stack, line);
+        if in_template_literal {
+            continue;
+        }
+        let indent = line.len() - line.trim_start_matches([' ', '\t']).len();
+        if indent == base_indent
+            && matches!(line.trim_start().chars().next(), Some('}' | ')' | ']'))
+        {
+            is_anchored = true;
+            break;
+        }
+    }
+    let content = Doc::list(reflow_with_indent(expr, true).collect());
+    if is_anchored {
+        content
+    } else {
+        content.nest(indent_width)
+    }
 }
 
 fn format_children_with_inserting_linebreak<'s, F>(

--- a/markup_fmt/tests/fmt/vue/interpolation/multiline-ternary.snap
+++ b/markup_fmt/tests/fmt/vue/interpolation/multiline-ternary.snap
@@ -1,0 +1,20 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<template>
+  <div class="mb-1 text-muted">
+    {{
+      state.ondertekening === "paraaf"
+        ? "paraaf arts:"
+        : "handtekening arts:"
+    }}
+  </div>
+  <span>
+    {{
+      formatName({
+        first: person.first,
+        last: person.last,
+      })
+    }}
+  </span>
+</template>

--- a/markup_fmt/tests/fmt/vue/interpolation/multiline-ternary.vue
+++ b/markup_fmt/tests/fmt/vue/interpolation/multiline-ternary.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="mb-1 text-muted">
+    {{
+      state.ondertekening === "paraaf"
+      ? "paraaf arts:"
+      : "handtekening arts:"
+    }}
+  </div>
+  <span>
+    {{
+      formatName({
+        first: person.first,
+        last: person.last,
+      })
+    }}
+  </span>
+</template>

--- a/markup_fmt/tests/fmt/vue/multiline-expr/fixture.snap
+++ b/markup_fmt/tests/fmt/vue/multiline-expr/fixture.snap
@@ -9,4 +9,11 @@ source: markup_fmt/tests/fmt.rs
   >
     <u-badge :label="row.original.acknowledgement.severity.label" />
   </u-tooltip>
+  <div
+    :data-raw="cond
+      ? `line one
+line two keeps raw template literal content`
+      : other"
+  >
+  </div>
 </template>

--- a/markup_fmt/tests/fmt/vue/multiline-expr/fixture.snap
+++ b/markup_fmt/tests/fmt/vue/multiline-expr/fixture.snap
@@ -1,0 +1,12 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<template>
+  <u-tooltip
+    :text="row.original.acknowledgement.severity.value === notice.severity.value
+      ? undefined
+      : `The acknowledged severity differs from the notice's, which was ${notice.severity.label}.`"
+  >
+    <u-badge :label="row.original.acknowledgement.severity.label" />
+  </u-tooltip>
+</template>

--- a/markup_fmt/tests/fmt/vue/multiline-expr/fixture.snap
+++ b/markup_fmt/tests/fmt/vue/multiline-expr/fixture.snap
@@ -16,4 +16,13 @@ line two keeps raw template literal content`
       : other"
   >
   </div>
+  <u-page-header
+    :title="page.title"
+    :ui="{
+      root: 'border-b border-default',
+      description: 'mt-1 text-muted',
+    }"
+    @close='emit("close");
+      reset()'
+  ></u-page-header>
 </template>

--- a/markup_fmt/tests/fmt/vue/multiline-expr/fixture.vue
+++ b/markup_fmt/tests/fmt/vue/multiline-expr/fixture.vue
@@ -6,4 +6,11 @@
   >
     <u-badge :label="row.original.acknowledgement.severity.label" />
   </u-tooltip>
+  <div
+    :data-raw="cond
+          ? `line one
+line two keeps raw template literal content`
+          : other"
+  >
+  </div>
 </template>

--- a/markup_fmt/tests/fmt/vue/multiline-expr/fixture.vue
+++ b/markup_fmt/tests/fmt/vue/multiline-expr/fixture.vue
@@ -1,0 +1,9 @@
+<template>
+  <u-tooltip
+    :text="row.original.acknowledgement.severity.value === notice.severity.value
+    ? undefined
+    : `The acknowledged severity differs from the notice's, which was ${notice.severity.label}.`"
+  >
+    <u-badge :label="row.original.acknowledgement.severity.label" />
+  </u-tooltip>
+</template>

--- a/markup_fmt/tests/fmt/vue/multiline-expr/fixture.vue
+++ b/markup_fmt/tests/fmt/vue/multiline-expr/fixture.vue
@@ -13,4 +13,13 @@ line two keeps raw template literal content`
           : other"
   >
   </div>
+  <u-page-header
+    :title="page.title"
+    :ui="{
+      root: 'border-b border-default',
+      description: 'mt-1 text-muted',
+    }"
+    @close='emit("close");
+    reset();'
+  ></u-page-header>
 </template>

--- a/markup_fmt/tests/fmt/vue/vue/attributes.snap
+++ b/markup_fmt/tests/fmt/vue/vue/attributes.snap
@@ -56,8 +56,8 @@ source: markup_fmt/tests/fmt.rs
     :key="index // hello"
     @click="() => {console.log(test)}"
     @click="() => {
-      console.log(test);
-    }"
+        console.log(test);
+      }"
     @click="doSomething()"
     @click="doSomething"
     @click="a.b"

--- a/markup_fmt/tests/fmt/vue/vue/attributes.snap
+++ b/markup_fmt/tests/fmt/vue/vue/attributes.snap
@@ -56,8 +56,8 @@ source: markup_fmt/tests/fmt.rs
     :key="index // hello"
     @click="() => {console.log(test)}"
     @click="() => {
-        console.log(test);
-      }"
+      console.log(test);
+    }"
     @click="doSomething()"
     @click="doSomething"
     @click="a.b"

--- a/markup_fmt/tests/fmt/vue/vue/interpolations.snap
+++ b/markup_fmt/tests/fmt/vue/vue/interpolations.snap
@@ -13,9 +13,9 @@ source: markup_fmt/tests/fmt.rs
     }} Eum quia nihil nulla esse. Dolorem asperiores vero est error {{
       preserve
 
-      invalid
+        invalid
 
-      interpolation
+        interpolation
     }} reprehenderit voluptates minus {{ console.log(  short_interpolation ) }}
     nemo.
   </div>


### PR DESCRIPTION
Closes #212

## Problem

Continuation lines of a multi-line attribute expression were printed at the same column as the attribute name, so a wrapped Vue binding read like a sibling attribute:

```html
<u-tooltip
  :text="row.original.acknowledgement.severity.value === notice.severity.value
  ? undefined
  : `The acknowledged severity differs from the notice's, which was ${notice.severity.label}.`"
>
```

## Changes

1. `format_attr_value` now nests the reflowed value by one extra `indent_width`, so continuation lines sit one level deeper than the attribute name. This is safe without parsing the expression: lines inside template literals are emitted through `Doc::empty_line`, which ignores indentation, so raw template literal content stays byte-for-byte intact.

2. `detect_indent` now skips lines that begin inside a template literal, using the same delimiter scanner that `reflow_with_indent` already had (extracted into a shared `update_pair_stack` helper). Their leading whitespace is literal content, not indentation. Previously such a line dragged the detected base indent down to 0, which left sibling expression lines one level deeper than intended and, when no external formatter renormalizes the expression, grew the indentation on every format run (formatting was not idempotent).

## Result

```html
<u-tooltip
  :text="row.original.acknowledgement.severity.value === notice.severity.value
    ? undefined
    : `The acknowledged severity differs from the notice's, which was ${notice.severity.label}.`"
>
```

## Tests

- New unit fixture (`tests/fmt/vue/multiline-expr`) and integration fixture (`issue-212.vue`, formatted with the real dprint-plugin-typescript) covering the ternary from the issue plus a multi-line template literal. The built-in stability check now also passes for the template literal case with an identity external formatter.
- Churn in existing snapshots is limited to `basic.vue` and `vue/attributes`, both showing the intended one-level shift of multi-line attribute values.
