### PR TITLE
Improve formatting of control structure to be consistant in and out of attributes

### DIFF
--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -947,6 +947,7 @@ impl<'s> DocGen<'s> for JinjaBlock<'s, Attribute<'s>> {
                 })
                 .collect(),
         )
+        .group()
     }
 }
 

--- a/markup_fmt/tests/fmt/jinja/attributes/control-structure.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/control-structure.jinja
@@ -1,0 +1,22 @@
+<select
+    {% if fname %}name="{{ fname }}"{% endif %}
+    {% if fid %}id="{{ fid }}"{% endif %}
+    {% if required %}required{% endif %}
+    {% if disabled %}disabled{% endif %}
+    {% if has_desc %}
+      aria-describedby="{{ fid }}-desc"
+    {% endif %}
+    class="select w-full validator"
+    {{ attrs }}
+>
+    {% if placeholder %}
+       <option value="" disabled selected>{{ placeholder }}</option>
+    {% endif %}
+    {{ slot }}
+</select>
+
+{% if fname %}name="{{ fname }}"{% endif %}
+{% if fid %}id="{{ fid }}"{% endif %}
+{% if required %}required{% endif %}
+{% if disabled %}disabled{% endif %}
+{% if has_desc %}aria-describedby="{{ fid }}-desc"{% endif %}

--- a/markup_fmt/tests/fmt/jinja/attributes/control-structure.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/control-structure.snap
@@ -1,0 +1,23 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<select
+  {% if fname %}name="{{ fname }}"{% endif %}
+  {% if fid %}id="{{ fid }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if has_desc %}aria-describedby="{{ fid }}-desc"{% endif %}
+  class="select w-full validator"
+  {{ attrs }}
+>
+  {% if placeholder %}
+    <option value="" disabled selected>{{ placeholder }}</option>
+  {% endif %}
+  {{ slot }}
+</select>
+
+{% if fname %}name="{{ fname }}"{% endif %}
+{% if fid %}id="{{ fid }}"{% endif %}
+{% if required %}required{% endif %}
+{% if disabled %}disabled{% endif %}
+{% if has_desc %}aria-describedby="{{ fid }}-desc"{% endif %}

--- a/markup_fmt/tests/fmt/jinja/attributes/single-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/single-attr.snap
@@ -23,9 +23,7 @@ source: markup_fmt/tests/fmt.rs
 </div>
 
 <picture
-  {% for key, val in attributes.items %}
-    {{ key }}="{{ val }}"
-  {% endfor %}
+  {% for key, val in attributes.items %}{{ key }}="{{ val }}"{% endfor %}
 >
 </picture>
 
@@ -40,18 +38,14 @@ source: markup_fmt/tests/fmt.rs
 
 <div
   {% if first_condition %}
-    {% if second_condition %}
-      data-second-condition="true"
-    {% endif %}
+    {% if second_condition %}data-second-condition="true"{% endif %}
   {% endif %}
 >
 </div>
 
 <div
   {% if first_condition %}
-    {% if second_condition %}
-      data-second-condition="true"
-    {% endif %}
+    {% if second_condition %}data-second-condition="true"{% endif %}
     data-first-condition="true"
   {% endif %}
 >
@@ -61,9 +55,7 @@ source: markup_fmt/tests/fmt.rs
 <div
   {% if first_condition %}
     data-first-condition="true"
-    {% if second_condition %}
-      data-second-condition="true"
-    {% endif %}
+    {% if second_condition %}data-second-condition="true"{% endif %}
   {% endif %}
 >
 </div>
@@ -71,12 +63,8 @@ source: markup_fmt/tests/fmt.rs
 # regression test for https://github.com/g-plane/markup_fmt/issues/198
 <div
   {% if first_condition %}
-    {% for key, value in my_dict.items %}
-      data-{{key}}="{{value}}"
-    {% endfor %}
-    {% if second_condition %}
-      data-second_condition="true"
-    {% endif %}
+    {% for key, value in my_dict.items %}data-{{key}}="{{value}}"{% endfor %}
+    {% if second_condition %}data-second_condition="true"{% endif %}
   {% else %}
     data-else="true"
   {% endif %}

--- a/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/tag-or-block-as-attr.snap
@@ -2,20 +2,14 @@
 source: markup_fmt/tests/fmt.rs
 ---
 <div
-  {% if colored_with_absolute_dates %}
-    colored-with-absolute-dates
-  {% endif %}
-  {% if colored_with_days %}
-    colored-with-days
-  {% endif %}
+  {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %}
+  {% if colored_with_days %}colored-with-days{% endif %}
 >
 </div>
 
 <div
   class="flex"
-  {% if colored_with_absolute_dates %}
-    colored-with-absolute-dates
-  {% endif %}
+  {% if colored_with_absolute_dates %}colored-with-absolute-dates{% endif %}
   id="3"
 >
 </div>
@@ -27,9 +21,7 @@ source: markup_fmt/tests/fmt.rs
 <input
   type="text"
   hidden
-  {% if widget.required is not False %}
-    required
-  {% endif %}
+  {% if widget.required is not False %}required{% endif %}
 />
 
 <details {% if category %}open{% endif %}>
@@ -70,9 +62,7 @@ source: markup_fmt/tests/fmt.rs
       data-{{key}}="{{value}}"
     {% endfor %}
   {% elif datepicker %}
-    {% if datepicker.should_delay %}
-      data-should_delay
-    {% endif %}
+    {% if datepicker.should_delay %}data-should_delay{% endif %}
   {% else %}
     data-start="08:30:00"
     data-end="20:30:00"
@@ -90,9 +80,7 @@ source: markup_fmt/tests/fmt.rs
   name="{{ field.name }}"
   id="id_{{ field.name }}{{ forloop.count }}"
   value="{{ choice.0 }}"
-  {% if choice.0 == field.value %}
-    checked="checked"
-  {% endif %}
+  {% if choice.0 == field.value %}checked="checked"{% endif %}
 />
 
 <input
@@ -100,27 +88,20 @@ source: markup_fmt/tests/fmt.rs
   type="radio"
   name="callback_method"
   value="callback"
-  {% if not office_open %}
-    disabled
-    class="hidden"
-  {% endif %}
+  {% if not office_open %}disabled class="hidden"{% endif %}
 >
 
 <div
   class="flex foo"
   id="index_id"
-  {% if index_type == "foo" %}
-    style="display: none"
-  {% endif %}
+  {% if index_type == "foo" %}style="display: none"{% endif %}
 >
   My text that should sometimes be hidden
 </div>
 
 <div
   data-toggle-mobile="true"
-  {% if "adsl" not in connectivity_technology %}
-    data-filter="fiber"
-  {% endif %}
+  {% if "adsl" not in connectivity_technology %}data-filter="fiber"{% endif %}
   class="foo bar baz yayayayayayaya"
 >
   Data attributes
@@ -131,9 +112,7 @@ source: markup_fmt/tests/fmt.rs
     <li>
       <a
         href="{{ subentry.url }}"
-        {% if subentry.active %}
-          class="dropdown-menu-selected"
-        {% endif %}
+        {% if subentry.active %}class="dropdown-menu-selected"{% endif %}
       >{{ subentry.name }}</a>
     </li>
   {% else %}


### PR DESCRIPTION
Prior to that, control structure would **always** expand which is often less readable.
It will now respect line width constraint and user explicit newlines

```diff
{% if outside_tag %}<p>Outside of a tag</p>{% endif %}
<div
-  {% if inside_tag_id %}id="inside-tag"{% endif %}
+  {% if inside_tag_id %}
+      id="inside-tag"
+  {% endif %}
    class="example-code"
></div>
```

See a real world exemple in the [playground](https://dprint.dev/playground/#code/DwZwpgNmDGAuBQACZiDeBSRBLAZonAdgIYC2Yi6AvsWQLwBEqq+N5lljmYBAJrhZSQoM2PDiw8BEhk3wTE7Tom588VIchH8ATmACOAVyy7JVXYeNgeIlf3Uo0mfnxBEARlFOUX7zzd52gg5aeAAWRCAA+jxgINACRNpYRAC0MXFJblZuAJ4yzOKS7Gmx0Eq2akEo0BARIAzgUHCIAO4pOAYQEIgAbkQQEkSwAPba9BpozEOw2iAKggB8EyGIAA610GChwxAx2gLAw6uwWMMEvf0GYAz0iD4eVoiNMLBWC7LrRJvbu2D77MAAPRHE5nd5cAKVZbMEAQYawebwIHPOBLIA/plugin/markup_fmt/ext/jinja)


- [x] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.
