### PR TITLE
Only parse front matter at the top of the document

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -2801,7 +2801,9 @@ impl<'s> Parser<'s> {
 
 /// Front matter is only front matter at the very top of the document, otherwise `---` is plain text.
 fn is_front_matter_start(source: &str, offset: usize) -> bool {
-    source.get(..offset).is_some_and(|s| s.trim_end().is_empty())
+    source
+        .get(..offset)
+        .is_some_and(|s| s.trim_end().is_empty())
 }
 
 /// Returns true if the provided character is a valid HTML tag name character.

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -2801,7 +2801,7 @@ impl<'s> Parser<'s> {
 
 /// Front matter is only front matter at the very top of the document, otherwise `---` is plain text.
 fn is_front_matter_start(source: &str, offset: usize) -> bool {
-    source[..offset].trim_end().is_empty()
+    source.get(..offset).is_some_and(|s| s.trim_end().is_empty())
 }
 
 /// Returns true if the provided character is a valid HTML tag name character.

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -32,12 +32,6 @@ pub struct Parser<'s> {
     source: &'s str,
     language: Language,
     chars: Peekable<CharIndices<'s>>,
-    state: ParserState,
-}
-
-#[derive(Default)]
-struct ParserState {
-    has_front_matter: bool,
 }
 
 impl<'s> Parser<'s> {
@@ -46,7 +40,6 @@ impl<'s> Parser<'s> {
             source,
             language,
             chars: source.char_indices().peekable(),
-            state: Default::default(),
         }
     }
 
@@ -1214,7 +1207,6 @@ impl<'s> Parser<'s> {
             }
         }
 
-        self.state.has_front_matter = true;
         Ok(FrontMatter {
             raw: unsafe { self.source.get_unchecked(start..end) },
             start,
@@ -1721,7 +1713,7 @@ impl<'s> Parser<'s> {
                     },
                 }
             }
-            Some((_, '-'))
+            Some((i, '-'))
                 if matches!(
                     self.language,
                     Language::Html
@@ -1729,7 +1721,7 @@ impl<'s> Parser<'s> {
                         | Language::Jinja
                         | Language::Vento
                         | Language::Mustache
-                ) && !self.state.has_front_matter =>
+                ) && is_front_matter_start(self.source, *i) =>
             {
                 let mut chars = self.chars.clone();
                 chars.next();
@@ -2532,7 +2524,8 @@ impl<'s> Parser<'s> {
                     }
                 }
                 Some((i, '-'))
-                    if matches!(self.language, Language::Astro) && !self.state.has_front_matter =>
+                    if matches!(self.language, Language::Astro)
+                        && is_front_matter_start(self.source, *i) =>
                 {
                     let i = *i;
                     let mut chars = self.chars.clone();
@@ -2804,6 +2797,11 @@ impl<'s> Parser<'s> {
         }
         Ok(XmlDecl { attrs })
     }
+}
+
+/// Front matter is only front matter at the very top of the document, otherwise `---` is plain text.
+fn is_front_matter_start(source: &str, offset: usize) -> bool {
+    source[..offset].trim_end().is_empty()
 }
 
 /// Returns true if the provided character is a valid HTML tag name character.

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -2803,7 +2803,7 @@ impl<'s> Parser<'s> {
 fn is_front_matter_start(source: &str, offset: usize) -> bool {
     source
         .get(..offset)
-        .is_some_and(|s| s.trim_end().is_empty())
+        .is_some_and(|s| s.chars().all(|c| c.is_ascii_whitespace()))
 }
 
 /// Returns true if the provided character is a valid HTML tag name character.

--- a/markup_fmt/tests/fmt/jinja/front-matter/not-front-matter.jinja
+++ b/markup_fmt/tests/fmt/jinja/front-matter/not-front-matter.jinja
@@ -1,0 +1,4 @@
+<span>---</span>
+{% if x %}
+---
+{% endif %}

--- a/markup_fmt/tests/fmt/jinja/front-matter/not-front-matter.snap
+++ b/markup_fmt/tests/fmt/jinja/front-matter/not-front-matter.snap
@@ -1,0 +1,7 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<span>---</span>
+{% if x %}
+  ---
+{% endif %}


### PR DESCRIPTION
Fixes #244

This is a minimal fix but I'm wondering if we should not do the frontmatter check in `parse_root` instead since [frontmatter is only expected at the start of the file](https://abhinav.github.io/doc2go/docs/usage/frontmatter/#:~:text=The%20block%20is%20expected%20at%20the%20top%20of%20the%20file%2C%20and%20is%20separated%20from%20the%20rest%20of%20the%20content%20by%20an%20empty%20line) ?

We currently pay (and were paying) the frontmatter check on every `-` in the document

Maybe something like that
```rust
pub fn parse_root(&mut self) -> PResult<Root<'s>> {
    let mut children = vec![];

    if matches!(
        self.language,
        Language::Html
            | Language::Astro
            | Language::Django
            | Language::Jinja
            | Language::Vento
            | Language::Mustache
    ) && self.source.starts_with("---")
    {
        let (kind, raw) = self.with_taken(|parser| {
            parser.parse_front_matter().map(NodeKind::FrontMatter)
        })?;
        children.push(Node { kind, raw });
    }

    while self.chars.peek().is_some() {
        children.push(self.parse_node()?);
    }

    Ok(Root { children })
}
```


- [x] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.
