### PR TITLE
prevent out-of-bounds slice in tag name on unterminated interpolation

### DIFF
--- a/markup_fmt/src/lib.rs
+++ b/markup_fmt/src/lib.rs
@@ -206,27 +206,27 @@ mod tests {
 
     #[test]
     fn unterminated_interpolation_in_tag_is_rejected() {
-        for input in [
+        [
             "<h{{ level }",
             "<input {{ field.attrs }",
             "<div data-{{ key }",
             "<option value={{ id }",
             "<div class=btn-{{ variant }",
-        ] {
+        ]
+        .iter()
+        .for_each(|input| {
             let err = format_text(input, Language::Jinja, &Default::default(), |code, _| {
                 Ok(Cow::from(code))
             })
             .unwrap_err();
-            assert!(
-                matches!(
-                    err,
-                    FormatError::Syntax(SyntaxError {
-                        kind: SyntaxErrorKind::ExpectAttrName,
-                        ..
-                    })
-                ),
-                "expected an attribute name error for {input:?}, got {err}"
+            std::assert_matches!(
+                err,
+                FormatError::Syntax(SyntaxError {
+                    kind: SyntaxErrorKind::ExpectAttrName,
+                    ..
+                }),
+                "expected an attribute name error for {input:?}, got {err}",
             );
-        }
+        });
     }
 }

--- a/markup_fmt/src/lib.rs
+++ b/markup_fmt/src/lib.rs
@@ -203,4 +203,30 @@ mod tests {
         );
         assert_eq!(ext.as_deref(), Some("tsx"));
     }
+
+    #[test]
+    fn unterminated_interpolation_in_tag_is_rejected() {
+        for input in [
+            "<h{{ level }",
+            "<input {{ field.attrs }",
+            "<div data-{{ key }",
+            "<option value={{ id }",
+            "<div class=btn-{{ variant }",
+        ] {
+            let err = format_text(input, Language::Jinja, &Default::default(), |code, _| {
+                Ok(Cow::from(code))
+            })
+            .unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    FormatError::Syntax(SyntaxError {
+                        kind: SyntaxErrorKind::ExpectAttrName,
+                        ..
+                    })
+                ),
+                "expected an attribute name error for {input:?}, got {err}"
+            );
+        }
+    }
 }

--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -743,9 +743,8 @@ impl<'s> Parser<'s> {
                     let mut chars = self.chars.clone();
                     chars.next();
                     if let Some((_, '{')) = chars.next() {
-                        let end =
-                            start + self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
-                        Some((start, end))
+                        self.parse_mustache_interpolation()?;
+                        Some((start, self.peek_pos()))
                     } else {
                         None
                     }
@@ -771,7 +770,8 @@ impl<'s> Parser<'s> {
                             break;
                         }
                         Some((_, '{')) => {
-                            end += self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
+                            self.parse_mustache_interpolation()?;
+                            end = self.peek_pos();
                         }
                         Some((_, c)) => {
                             end += c.len_utf8();
@@ -870,11 +870,10 @@ impl<'s> Parser<'s> {
                                 })?;
                             }
                             Some((_, '{')) => {
-                                chars.next();
+                                self.parse_mustache_interpolation()?;
                                 // We use inclusive range when returning string,
                                 // so we need to substract 1 here.
-                                let (interpolation, _) = self.parse_mustache_interpolation()?;
-                                end += interpolation.len() + "{{}}".len() - 1;
+                                end = self.peek_pos() - 1;
                             }
                             _ => {
                                 self.chars.next();
@@ -2433,11 +2432,11 @@ impl<'s> Parser<'s> {
                 end = *i + c.len_utf8();
                 self.chars.next();
             } else if *c == '{' && matches!(self.language, Language::Jinja) {
-                let current_i = *i;
                 let mut chars = self.chars.clone();
                 chars.next();
                 if chars.next_if(|(_, c)| *c == '{').is_some() {
-                    end = current_i + self.parse_mustache_interpolation()?.0.len() + "{{}}".len();
+                    self.parse_mustache_interpolation()?;
+                    end = self.peek_pos();
                 } else {
                     break;
                 }


### PR DESCRIPTION
It used to read out of bound for the cases in `unterminated_interpolation_in_tag_is_rejected` where the document stop before the hardcoded {{ }} offset

- [x] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.
