### PR TITLE
Fix indent level for externally formatted `<script>` inside control structure

### DIFF
--- a/dprint_plugin/tests/integration/dprint_ts/script-in-control-structure.jinja.snap
+++ b/dprint_plugin/tests/integration/dprint_ts/script-in-control-structure.jinja.snap
@@ -1,0 +1,17 @@
+---
+source: dprint_plugin/tests/integration.rs
+---
+{% if enabled %}
+  <script>
+  document.addEventListener("DOMContentLoaded", () => {
+    console.log("nested");
+  });
+  </script>
+{% endif %}
+{% for item in items %}
+  {% if item %}
+    <script>
+    console.log("deep");
+    </script>
+  {% endif %}
+{% endfor %}

--- a/dprint_plugin/tests/integration/script-in-control-structure.jinja
+++ b/dprint_plugin/tests/integration/script-in-control-structure.jinja
@@ -1,0 +1,14 @@
+{% if enabled %}
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      console.log("nested");
+    });
+  </script>
+{% endif %}
+{% for item in items %}
+  {% if item %}
+    <script>
+      console.log("deep");
+    </script>
+  {% endif %}
+{% endfor %}

--- a/markup_fmt/src/printer.rs
+++ b/markup_fmt/src/printer.rs
@@ -2746,7 +2746,13 @@ where
         ] if is_all_ascii_whitespace(text_node.raw) => Doc::line_or_space(),
         _ => format_ws_sensitive_leading_ws(children)
             .append(format_children_without_inserting_linebreak(
-                children, ctx, state,
+                children,
+                ctx,
+                // Children are nested below, so external formatters must see the deeper indent.
+                &State {
+                    indent_level: state.indent_level + 1,
+                    ..*state
+                },
             ))
             .nest(ctx.indent_width)
             .append(format_ws_sensitive_trailing_ws(children)),


### PR DESCRIPTION
The Doc was nested one level deeper but `state.indent_level` was left unchanged, so external formatters (in that case, `script_formatter`) received an undercounted indent hint for scripts inside control structure blocks.

So it was doing that when ran with any js external formater:

```diff
 {% if enabled %}
   <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      console.log("nested");
-    });
+  document.addEventListener("DOMContentLoaded", () => {
+  console.log("nested");
+});
   </script>
 {% endif %}
```

- [x] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.
