### PR TITLE
treat lone `{` in quoted attribute values as literal text

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -824,7 +824,15 @@ impl<'s> Parser<'s> {
                         }
                     }
                     Some((_, '{')) if can_interpolate => {
-                        chars_stack.push('{');
+                        // Outside Svelte, a lone `{` is literal text, so only `{{`, `{%` and `{#` open an interpolation.
+                        if matches!(self.language, Language::Svelte)
+                            || self
+                                .chars
+                                .peek()
+                                .is_some_and(|(_, c)| matches!(c, '{' | '%' | '#'))
+                        {
+                            chars_stack.push('{');
+                        }
                     }
                     Some((_, '}'))
                         if can_interpolate

--- a/markup_fmt/tests/fmt/jinja/attributes/brace-in-attr-value.jinja
+++ b/markup_fmt/tests/fmt/jinja/attributes/brace-in-attr-value.jinja
@@ -1,0 +1,6 @@
+<dv l="{"></dv>
+<dv l={></dv>
+<dv l="a { b"></dv>
+<dv l="{ {{ x }}"></dv>
+<dv l="}"></dv>
+<dv l="{{ url }}"></dv>

--- a/markup_fmt/tests/fmt/jinja/attributes/brace-in-attr-value.snap
+++ b/markup_fmt/tests/fmt/jinja/attributes/brace-in-attr-value.snap
@@ -1,0 +1,9 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+<dv l="{"></dv>
+<dv l="{"></dv>
+<dv l="a { b"></dv>
+<dv l="{ {{ x }}"></dv>
+<dv l="}"></dv>
+<dv l="{{ url }}"></dv>


### PR DESCRIPTION
Sry for all the mr's, I'm trying to release a v1 of djangofmt so I'm taming the edges.

- [x] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.
