### PR TITLE
don't duplicate `---` when front matter is unterminated

### DIFF
--- a/markup_fmt/src/parser.rs
+++ b/markup_fmt/src/parser.rs
@@ -1144,7 +1144,7 @@ impl<'s> Parser<'s> {
         let start = start + 1;
 
         let mut pair_stack = vec![];
-        let mut end = start;
+        let end;
         loop {
             match self.chars.next() {
                 Some((i, '-')) if pair_stack.is_empty() => {
@@ -1203,7 +1203,8 @@ impl<'s> Parser<'s> {
                     self.chars.next();
                 }
                 Some(..) => continue,
-                None => break,
+                // Reaching the end of the file means there's no closing delimiter, so this isn't front matter.
+                None => return Err(self.emit_error(SyntaxErrorKind::ExpectFrontMatter)),
             }
         }
 
@@ -1726,7 +1727,9 @@ impl<'s> Parser<'s> {
                 let mut chars = self.chars.clone();
                 chars.next();
                 if let Some(((_, '-'), (_, '-'))) = chars.next().zip(chars.next()) {
-                    self.parse_front_matter().map(NodeKind::FrontMatter)
+                    self.try_parse(Parser::parse_front_matter)
+                        .map(NodeKind::FrontMatter)
+                        .or_else(|_| self.parse_text_node().map(NodeKind::Text))
                 } else {
                     self.parse_text_node().map(NodeKind::Text)
                 }

--- a/markup_fmt/tests/fmt/astro/front-matter/unterminated.astro
+++ b/markup_fmt/tests/fmt/astro/front-matter/unterminated.astro
@@ -1,0 +1,2 @@
+---
+const foo = "bar"

--- a/markup_fmt/tests/fmt/astro/front-matter/unterminated.snap
+++ b/markup_fmt/tests/fmt/astro/front-matter/unterminated.snap
@@ -1,0 +1,4 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+--- const foo = "bar"

--- a/markup_fmt/tests/fmt/jinja/front-matter/unterminated.jinja
+++ b/markup_fmt/tests/fmt/jinja/front-matter/unterminated.jinja
@@ -1,0 +1,2 @@
+---
+description: unterminated front matter

--- a/markup_fmt/tests/fmt/jinja/front-matter/unterminated.snap
+++ b/markup_fmt/tests/fmt/jinja/front-matter/unterminated.snap
@@ -1,0 +1,4 @@
+---
+source: markup_fmt/tests/fmt.rs
+---
+--- description: unterminated front matter


### PR DESCRIPTION
Formatting unterminated frointmatter was deleting all the content

This 
```html
---
const foo = "bar"
```
Would become

```html
---

---
```

See [playground](https://dprint.dev/playground/#code/LQhQGMHsDsGcBcAEAzSlEF5ECIBGBDAJ21CA/plugin/markup_fmt/ext/astro)

- [x] The pull request description was written manually by me and was not generated by an AI tool or agent.
- [x] I have read and understood the relevant parts of the existing codebase before making these changes.
- [x] I have carefully reviewed and understood all code changes, and ensured that they match the style, architecture, and conventions of the existing codebase.
- [x] I understand that pull requests containing blindly generated or unreviewed AI-generated code may be closed without review.
